### PR TITLE
:heavy_minus_sign: Removed boost requirements from the Lorem module

### DIFF
--- a/include/faker-cxx/Lorem.h
+++ b/include/faker-cxx/Lorem.h
@@ -8,6 +8,6 @@ class Lorem
 {
 public:
     static std::string word();
-    static std::string words(int numberOfWords = 3);
+    static std::string words(size_t numberOfWords = 3);
 };
 }

--- a/src/Lorem.cpp
+++ b/src/Lorem.cpp
@@ -1,9 +1,9 @@
 #include "Lorem.h"
 
-#include <boost/algorithm/string/join.hpp>
-
+#include <sstream>
 #include "data/LoremWords.h"
 #include "Helper.h"
+
 
 namespace faker
 {
@@ -12,15 +12,20 @@ std::string Lorem::word()
     return Helper::arrayElement<std::string>(loremWords);
 }
 
-std::string Lorem::words(int numberOfWords)
+std::string Lorem::words(size_t numberOfWords)
 {
-    std::vector<std::string> words;
+    std::ostringstream words_accumulator;
 
-    for (int i = 0; i < numberOfWords; i++)
+    for (size_t i = 0; i < (numberOfWords - 1); ++i)
     {
-        words.push_back(word());
+        words_accumulator << word() << " ";
     }
 
-    return boost::algorithm::join(words, " ");
+    if (numberOfWords > 0) [[likely]]
+        words_accumulator << word();
+
+    return words_accumulator.str();
+    // walk back one space to remove the trailing space
+
 }
 }


### PR DESCRIPTION
Extremely minuscule pull request, but I figured you'd want this in main ASAP.

Removed the requirement of boost::algorithm from lorem by using stringstreams to perform the join of words.