### PR TITLE
add hsl-function to color module

### DIFF
--- a/include/faker-cxx/Color.h
+++ b/include/faker-cxx/Color.h
@@ -50,5 +50,17 @@ public:
      */
     static std::string hex(HexCasing casing = HexCasing::Lower, HexPrefix prefix = HexPrefix::Hash,
                            bool includeAlpha = false);
+
+    /**
+     * @brief Returns an HSL color.
+     *
+     * @param includeAlpha Adds an alpha value to the color (HSLA). Defaults to `false`.
+     * @returns HSL color formatted with hsl(X,X,X) or hsla(X,X,X,X).
+     * @code
+     * Color::hsl() // "hsl(0, 20, 100)"
+     * Color::hsl(true) // "hsla(0, 0, 100, 0.50)"
+     * @endcode
+     */
+    static std::string hsl(bool includeAlpha = false);
 };
 }

--- a/src/modules/color/Color.cpp
+++ b/src/modules/color/Color.cpp
@@ -46,4 +46,26 @@ std::string Color::hex(HexCasing casing, HexPrefix prefix, bool includeAlpha)
 
     return String::hexadecimal(6, casing, prefix);
 }
+std::string Color::hsl(bool includeAlpha)
+{
+    const std::integral auto hue = Number::integer(360);
+    const std::integral auto saturation = Number::integer(100);
+    const std::integral auto lightness = Number::integer(100);
+
+    if (!includeAlpha)
+    {
+        return fmt::format("hsl({}, {}, {})", hue, saturation, lightness);
+    }
+
+    const std::floating_point auto alpha = Number::decimal<double>(1);
+
+    std::stringstream ss;
+    ss << std::fixed;
+    ss.precision(2);
+    ss << alpha;
+    const auto formattedAlpha = ss.str();
+
+    return fmt::format("hsla({}, {}, {}, {})", hue, saturation, lightness, formattedAlpha);
+}
+
 }

--- a/src/modules/color/ColorTest.cpp
+++ b/src/modules/color/ColorTest.cpp
@@ -88,3 +88,42 @@ TEST_F(ColorTest, shouldGenerateHexColorWithAlpha)
     ASSERT_TRUE(std::ranges::any_of(hexNumber, [hexNumber](char hexNumberCharacter)
                                     { return hexUpperCharacters.find(hexNumberCharacter) != std::string::npos; }));
 }
+
+TEST_F(ColorTest, shouldGenerateHslWithoutAlpha)
+{
+    const auto generatedHslColor = faker::Color::hsl();
+    const auto hslValues = faker::StringHelper::split(generatedHslColor.substr(4, generatedHslColor.size() - 1), " ");
+
+    int hue, staturation, lightness;
+
+    std::from_chars(hslValues[0].data(), hslValues[0].data() + hslValues[0].size(), hue);
+    std::from_chars(hslValues[1].data(), hslValues[1].data() + hslValues[1].size(), staturation);
+    std::from_chars(hslValues[2].data(), hslValues[2].data() + hslValues[2].size(), lightness);
+
+    ASSERT_TRUE(generatedHslColor.starts_with("hsl("));
+    ASSERT_TRUE(generatedHslColor.ends_with(")"));
+    ASSERT_TRUE(hue >= 0 && hue <= 360);
+    ASSERT_TRUE(staturation >= 0 && staturation <= 100);
+    ASSERT_TRUE(lightness >= 0 && lightness <= 100);
+}
+
+TEST_F(ColorTest, shouldGenerateHslWithAlpha)
+{
+    const auto generatedHslaColor = faker::Color::hsl(true);
+    const auto hslValues = faker::StringHelper::split(generatedHslaColor.substr(5, generatedHslaColor.size() - 1), " ");
+
+    int hue, staturation, lightness;
+    double alpha;
+
+    std::from_chars(hslValues[0].data(), hslValues[0].data() + hslValues[0].size(), hue);
+    std::from_chars(hslValues[1].data(), hslValues[1].data() + hslValues[1].size(), staturation);
+    std::from_chars(hslValues[2].data(), hslValues[2].data() + hslValues[2].size(), lightness);
+    std::from_chars(hslValues[3].data(), hslValues[3].data() + hslValues[3].size(), alpha);
+
+    ASSERT_TRUE(generatedHslaColor.starts_with("hsla("));
+    ASSERT_TRUE(generatedHslaColor.ends_with(")"));
+    ASSERT_TRUE(hue >= 0 && hue <= 360);
+    ASSERT_TRUE(staturation >= 0 && staturation <= 100);
+    ASSERT_TRUE(lightness >= 0 && lightness <= 100);
+    ASSERT_TRUE(alpha >= 0 && alpha <= 1);
+}


### PR DESCRIPTION
add hsl() function in Color module to generate random color in hsl format. Supports alpha and no-alpha colors.