### PR TITLE
Fix conversion error in GitTest.cpp

### DIFF
--- a/src/modules/git/GitTest.cpp
+++ b/src/modules/git/GitTest.cpp
@@ -39,7 +39,7 @@ std::string GitTest::generateShaRegex()
 TEST_F(GitTest, shouldGenerateBranch)
 {
     const auto branch = Git::branch();
-    unsigned long branchSplit = faker::StringHelper::split(branch, "-").size();
+    const auto branchSplit = faker::StringHelper::split(branch, "-").size();
 
     ASSERT_TRUE(2 <= branchSplit && branchSplit <= 7);
 }


### PR DESCRIPTION
A conversion warning in GitTest.cpp was preventing compilation using MinGW on Windows.