### PR TITLE
refactor: Overloaded `String::binary()` and `String::octal()`

### DIFF
--- a/include/faker-cxx/String.h
+++ b/include/faker-cxx/String.h
@@ -228,16 +228,29 @@ public:
     /**
      * @brief Generates a binary string.
      *
+     * @param length The number of digits to generate. Defaults to `1`.
+     *
+     * @returns Binary string.
+     *
+     * @code
+     * String::binary(8) // "0b01110101"
+     * @endcode
+     */
+    static std::string binary(unsigned length = 1);
+
+    /**
+     * @brief Generates a binary string.
+     *
      * @param guarantee A map specifying char count constraints if any
      * @param length The number of digits to generate. Defaults to `1`.
      *
      * @returns Binary string.
      *
      * @code
-     * String::binary({}, 8) // "0b01110101"
+     * String::binary({'1',{7,8}}, 8) // "0b11110111"
      * @endcode
      */
-    static std::string binary(GuaranteeMap&& guarantee = {}, unsigned length = 1);
+    static std::string binary(GuaranteeMap&& guarantee, unsigned length = 1);
 
     /**
      * @brief Generates an octal string.

--- a/include/faker-cxx/String.h
+++ b/include/faker-cxx/String.h
@@ -242,15 +242,28 @@ public:
     /**
      * @brief Generates an octal string.
      *
+     * @param length The number of digits to generate. Defaults to `1`.
+     *
+     * @returns Octal string.
+     *
+     * @code
+     * String::octal(8) // "0o52561721"
+     * @endcode
+     */
+    static std::string octal(unsigned length = 1);
+
+    /**
+     * @brief Generates an octal string.
+     *
      * @param guarantee A map specifying char count constraints if any
      * @param length The number of digits to generate. Defaults to `1`.
      *
      * @returns Octal string.
      *
      * @code
-     * String::octal({}, 8) // "0o52561721"
+     * String::octal({'4',{4,5}}, 8) // "0o42444041"
      * @endcode
      */
-    static std::string octal(GuaranteeMap&& guarantee = {}, unsigned length = 1);
+    static std::string octal(GuaranteeMap&& guarantee, unsigned length = 1);
 };
 }

--- a/src/modules/string/String.cpp
+++ b/src/modules/string/String.cpp
@@ -219,6 +219,15 @@ std::string String::binary(GuaranteeMap&& guarantee, unsigned int length)
     return "0b" + generateStringWithGuarantee(guarantee, targetCharacters, length);
 }
 
+std::string String::octal(unsigned int length)
+{
+    std::string octalNumber;
+    for (unsigned int i = 0; i < length; ++i)
+    {
+        octalNumber += static_cast<char>(Number::integer(7));
+    }
+    return "0o" + octalNumber;
+}
 std::string String::octal(GuaranteeMap&& guarantee, unsigned int length)
 {
     // numbers used by octal representation

--- a/src/modules/string/String.cpp
+++ b/src/modules/string/String.cpp
@@ -206,6 +206,16 @@ std::string String::hexadecimal(unsigned int length, HexCasing casing, HexPrefix
     return hexadecimal;
 }
 
+std::string String::binary(unsigned int length)
+{
+    std::string binaryNumber;
+    for (unsigned int i = 0; i < length; ++i)
+    {
+        binaryNumber += static_cast<char>(Number::integer(1));
+    }
+    return "0b" + binaryNumber;
+}
+
 std::string String::binary(GuaranteeMap&& guarantee, unsigned int length)
 {
     // numbers used by binary representation

--- a/src/modules/string/StringTest.cpp
+++ b/src/modules/string/StringTest.cpp
@@ -355,7 +355,7 @@ TEST_F(StringTest, shouldGenerateBinary)
 {
     const auto binaryLength = 8;
 
-    const auto binary = String::binary({}, binaryLength);
+    const auto binary = String::binary(binaryLength);
 
     const auto prefix = binary.substr(0, 2);
     const auto binaryNumber = binary.substr(2);
@@ -373,19 +373,25 @@ TEST_F(StringTest, shouldGenerateBinaryWithGuarantee1)
     // atleast 3 '0' and 2 '1'
     // atmost 7 '0' and 7 '1'
     faker::GuaranteeMap guarantee{{'0', {3, 7}}, {'1', {2, 7}}};
-    const auto binary = String::binary(std::move(guarantee), binaryLength);
+    // it is a random function so lets test for 20 random generations
+    for (int i = 0; i < 20; ++i)
+    {
+        auto copyGuarantee = guarantee;
+        const auto binary = String::binary(std::move(copyGuarantee), binaryLength);
 
-    const auto prefix = binary.substr(0, 2);
-    const auto binaryNumber = binary.substr(2);
+        const auto prefix = binary.substr(0, 2);
+        const auto binaryNumber = binary.substr(2);
 
-    ASSERT_EQ(binaryNumber.size(), binaryLength);
-    ASSERT_EQ(prefix, "0b");
-    ASSERT_TRUE(std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
-                                    { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
-    auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
-    auto count_1 = std::count(binaryNumber.begin(), binaryNumber.end(), '1');
-    ASSERT_TRUE(count_0 >= 3 && count_0 <= 7);
-    ASSERT_TRUE(count_1 >= 2 && count_1 <= 7);
+        ASSERT_EQ(binaryNumber.size(), binaryLength);
+        ASSERT_EQ(prefix, "0b");
+        ASSERT_TRUE(
+            std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
+                                { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
+        auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
+        auto count_1 = std::count(binaryNumber.begin(), binaryNumber.end(), '1');
+        ASSERT_TRUE(count_0 >= 3 && count_0 <= 7);
+        ASSERT_TRUE(count_1 >= 2 && count_1 <= 7);
+    }
 }
 TEST_F(StringTest, shouldGenerateBinaryWithGuarantee2)
 {
@@ -393,19 +399,25 @@ TEST_F(StringTest, shouldGenerateBinaryWithGuarantee2)
 
     // exactly 8 '0' and 2 '1'
     faker::GuaranteeMap guarantee{{'0', {8, 8}}, {'1', {2, 2}}};
-    const auto binary = String::binary(std::move(guarantee), binaryLength);
+    // it is a random function so lets test for 20 random generations
+    for (int i = 0; i < 20; ++i)
+    {
+        auto copyGuarantee = guarantee;
+        const auto binary = String::binary(std::move(copyGuarantee), binaryLength);
 
-    const auto prefix = binary.substr(0, 2);
-    const auto binaryNumber = binary.substr(2);
+        const auto prefix = binary.substr(0, 2);
+        const auto binaryNumber = binary.substr(2);
 
-    ASSERT_EQ(binaryNumber.size(), binaryLength);
-    ASSERT_EQ(prefix, "0b");
-    ASSERT_TRUE(std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
-                                    { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
-    auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
-    auto count_1 = std::count(binaryNumber.begin(), binaryNumber.end(), '1');
-    ASSERT_TRUE(count_0 == 8);
-    ASSERT_TRUE(count_1 == 2);
+        ASSERT_EQ(binaryNumber.size(), binaryLength);
+        ASSERT_EQ(prefix, "0b");
+        ASSERT_TRUE(
+            std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
+                                { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
+        auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
+        auto count_1 = std::count(binaryNumber.begin(), binaryNumber.end(), '1');
+        ASSERT_TRUE(count_0 == 8);
+        ASSERT_TRUE(count_1 == 2);
+    }
 }
 TEST_F(StringTest, shouldGenerateBinaryWithGuarantee3)
 {
@@ -413,17 +425,23 @@ TEST_F(StringTest, shouldGenerateBinaryWithGuarantee3)
 
     // atleast 10 '0'
     faker::GuaranteeMap guarantee{{'0', {10}}};
-    const auto binary = String::binary(std::move(guarantee), binaryLength);
+    // it is a random function so lets test for 20 random generations
+    for (int i = 0; i < 20; ++i)
+    {
+        auto copyGuarantee = guarantee;
+        const auto binary = String::binary(std::move(copyGuarantee), binaryLength);
 
-    const auto prefix = binary.substr(0, 2);
-    const auto binaryNumber = binary.substr(2);
+        const auto prefix = binary.substr(0, 2);
+        const auto binaryNumber = binary.substr(2);
 
-    ASSERT_EQ(binaryNumber.size(), binaryLength);
-    ASSERT_EQ(prefix, "0b");
-    ASSERT_TRUE(std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
-                                    { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
-    auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
-    ASSERT_TRUE(count_0 == 10);
+        ASSERT_EQ(binaryNumber.size(), binaryLength);
+        ASSERT_EQ(prefix, "0b");
+        ASSERT_TRUE(
+            std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
+                                { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
+        auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
+        ASSERT_TRUE(count_0 == 10);
+    }
 }
 
 TEST_F(StringTest, shouldGenerateBinaryWithGuarantee4)
@@ -432,17 +450,23 @@ TEST_F(StringTest, shouldGenerateBinaryWithGuarantee4)
 
     // atmost 0 '0'
     faker::GuaranteeMap guarantee{{'0', {0, 0}}};
-    const auto binary = String::binary(std::move(guarantee), binaryLength);
+    // it is a random function so lets test for 20 random generations
+    for (int i = 0; i < 20; ++i)
+    {
+        auto copyGuarantee = guarantee;
+        const auto binary = String::binary(std::move(copyGuarantee), binaryLength);
 
-    const auto prefix = binary.substr(0, 2);
-    const auto binaryNumber = binary.substr(2);
+        const auto prefix = binary.substr(0, 2);
+        const auto binaryNumber = binary.substr(2);
 
-    ASSERT_EQ(binaryNumber.size(), binaryLength);
-    ASSERT_EQ(prefix, "0b");
-    ASSERT_TRUE(std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
-                                    { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
-    auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
-    ASSERT_TRUE(count_0 == 0);
+        ASSERT_EQ(binaryNumber.size(), binaryLength);
+        ASSERT_EQ(prefix, "0b");
+        ASSERT_TRUE(
+            std::ranges::any_of(binaryNumber, [](char binaryNumberCharacter)
+                                { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
+        auto count_0 = std::count(binaryNumber.begin(), binaryNumber.end(), '0');
+        ASSERT_TRUE(count_0 == 0);
+    }
 }
 
 TEST_F(StringTest, invalidGuaranteeForBinary1)
@@ -499,7 +523,8 @@ TEST_F(StringTest, shouldGenerateOctalWithGuarantee1)
     // it is a random function so lets test for 20 random generations
     for (int i = 0; i < 20; ++i)
     {
-        const auto octal = String::octal(std::move(guarantee), octalLength);
+        auto copyGuarantee = guarantee;
+        const auto octal = String::octal(std::move(copyGuarantee), octalLength);
 
         const auto prefix = octal.substr(0, 2);
         const auto octalNumber = octal.substr(2);
@@ -532,7 +557,8 @@ TEST_F(StringTest, shouldGenerateOctalWithGuarantee2)
     // it is a random function so lets test for 20 random generations
     for (int i = 0; i < 20; ++i)
     {
-        const auto octal = String::octal(std::move(guarantee), octalLength);
+        auto copyGuarantee = guarantee;
+        const auto octal = String::octal(std::move(copyGuarantee), octalLength);
 
         const auto prefix = octal.substr(0, 2);
         const auto octalNumber = octal.substr(2);

--- a/src/modules/string/StringTest.cpp
+++ b/src/modules/string/StringTest.cpp
@@ -477,7 +477,7 @@ TEST_F(StringTest, shouldGenerateOctalWithPrefix)
 {
     const auto octalLength = 8;
 
-    const auto octal = String::octal({}, octalLength);
+    const auto octal = String::octal(octalLength);
 
     const auto prefix = octal.substr(0, 2);
     const auto octalNumber = octal.substr(2);


### PR DESCRIPTION
I overloaded these functions so that if user don't want to use string guarantees, they wont have to deal with an unnecessary parameter of `GuaranteeMap`.
Let me know if you like it this way or not, I will work on other functions accordingly.