### PR TITLE
Make sure that min and max do not collide with Windows.h macros

### DIFF
--- a/include/faker-cxx/String.h
+++ b/include/faker-cxx/String.h
@@ -22,8 +22,8 @@ enum class StringCasing
 
 struct CharCount
 {
-    unsigned int atleastCount{std::numeric_limits<unsigned int>::min()};
-    unsigned int atmostCount{std::numeric_limits<unsigned int>::max()};
+    unsigned int atleastCount{(std::numeric_limits<unsigned int>::min)()};
+    unsigned int atmostCount{(std::numeric_limits<unsigned int>::max)()};
 };
 
 /*


### PR DESCRIPTION
This is a minor improvement for people that work under the OS Windows and happen to include both `Windows.h` and `include/faker-cxx/String.h`. The header `Windows.h` might define the macros `min` and `max` which then leads to a compilation error in line 25 and 26 in the `CharCount` class.