### PR TITLE
Expanded BIC Countries

### DIFF
--- a/include/faker-cxx/types/BicCountry.h
+++ b/include/faker-cxx/types/BicCountry.h
@@ -7,8 +7,20 @@ namespace faker
 enum class BicCountry
 {
     Poland,
+    United_States,
+    United_Kingdom,
+    Germany,
+    Romania,
+    France,
+    Italy,
+    Spain,
+    Netherlands,
+    India,
 };
 
-const std::vector<BicCountry> supportedBicCountries{BicCountry::Poland};
+const std::vector<BicCountry> supportedBicCountries{BicCountry::Poland, BicCountry::United_States,
+                                                    BicCountry::United_Kingdom, BicCountry::Germany,
+                                                    BicCountry::Romania, BicCountry::France, BicCountry::Italy,
+                                                    BicCountry::Spain, BicCountry::Netherlands, BicCountry::India};
 
 }

--- a/src/modules/finance/FinanceTest.cpp
+++ b/src/modules/finance/FinanceTest.cpp
@@ -7,7 +7,6 @@
 
 #include "gtest/gtest.h"
 
-#include "../../common/FormatHelper.h"
 #include "../../common/LuhnCheck.h"
 #include "../../common/StringHelper.h"
 #include "../string/data/Characters.h"
@@ -80,6 +79,19 @@ const std::map<IbanCountry, std::string> generatedTestName{
     {IbanCountry::Slovenia, "shouldGenerateSloveniaIban"},
     {IbanCountry::Spain, "shouldGenerateSpainIban"},
     {IbanCountry::Sweden, "shouldGenerateSwedenIban"},
+};
+
+const std::map<BicCountry, std::string> generatedBicTestName{
+    {BicCountry::Poland, "shouldGeneratePolandBic"},
+    {BicCountry::United_States, "shouldGenerateUnitedStatesBic"},
+    {BicCountry::United_Kingdom, "shouldGenerateUnitedKingdomBic"},
+    {BicCountry::Germany, "shouldGenerateGermanyBic"},
+    {BicCountry::Romania, "shouldGenerateRomaniaBic"},
+    {BicCountry::France, "shouldGenerateFranceBic"},
+    {BicCountry::Italy, "shouldGenerateItalyBic"},
+    {BicCountry::Spain, "shouldGenerateSpainBic"},
+    {BicCountry::Netherlands, "shouldGenerateNetherlandsBic"},
+    {BicCountry::India, "shouldGenerateIndiaBic"},
 };
 }
 
@@ -216,26 +228,6 @@ TEST_F(FinanceTest, shouldGenerateIban)
                 iban.starts_with("LT") || iban.starts_with("LU") || iban.starts_with("MT") || iban.starts_with("NL") ||
                 iban.starts_with("PL") || iban.starts_with("PT") || iban.starts_with("RO") || iban.starts_with("SK") ||
                 iban.starts_with("SI") || iban.starts_with("ES") || iban.starts_with("SE"));
-}
-
-TEST_F(FinanceTest, shouldGenerateBic)
-{
-    const auto bic = Finance::bic();
-
-    const auto polandBankIdentifiersCodes = bankIdentifiersCodesMapping.at(BicCountry::Poland);
-
-    ASSERT_TRUE(std::ranges::any_of(polandBankIdentifiersCodes, [bic](const std::string& polandBankIdentifierCode)
-                                    { return bic == polandBankIdentifierCode; }));
-}
-
-TEST_F(FinanceTest, shouldGeneratePolandBic)
-{
-    const auto bic = Finance::bic(BicCountry::Poland);
-
-    const auto polandBankIdentifiersCodes = bankIdentifiersCodesMapping.at(BicCountry::Poland);
-
-    ASSERT_TRUE(std::ranges::any_of(polandBankIdentifiersCodes, [bic](const std::string& polandBankIdentifierCode)
-                                    { return bic == polandBankIdentifierCode; }));
 }
 
 TEST_F(FinanceTest, shouldGenerateAccountNumber)
@@ -393,3 +385,27 @@ TEST_F(FinanceTest, shouldGenerateEthereumAddress)
     ASSERT_TRUE(std::ranges::any_of(hexNumber, [hexNumber](char hexNumberCharacter)
                                     { return hexLowerCharacters.find(hexNumberCharacter) != std::string::npos; }));
 }
+
+
+class FinanceBicTest : public TestWithParam<BicCountry>
+{
+};
+
+TEST_P(FinanceBicTest, CheckBicGenerator)
+{
+    const auto country = GetParam();
+
+    const auto bic = Finance::bic(country);
+
+    const auto& bankIdentifiersCodes = bankIdentifiersCodesMapping.at(country);
+
+    ASSERT_TRUE(std::ranges::any_of(bankIdentifiersCodes, [bic](const std::string& bankIdentifierCode) {
+                                        return bic == bankIdentifierCode;
+                                    }));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestBicGenerator, FinanceBicTest,
+                         Values(BicCountry::Poland, BicCountry::United_States, BicCountry::United_Kingdom,
+                                BicCountry::Germany, BicCountry::Romania, BicCountry::France, BicCountry::Italy,
+                                BicCountry::Spain, BicCountry::Netherlands, BicCountry::India),
+                         [](const TestParamInfo<BicCountry>& info) { return generatedBicTestName.at(info.param); });

--- a/src/modules/finance/data/BankIndentifiersCodes.h
+++ b/src/modules/finance/data/BankIndentifiersCodes.h
@@ -11,7 +11,25 @@ namespace faker
 const std::map<BicCountry, std::vector<std::string>> bankIdentifiersCodesMapping = {
     {BicCountry::Poland,
      {"BPKOPLPW", "PKOPPLPW", "BREXPLPWMUL", "BNPAPLP", "POLUPLPR", "BIGBPLPW", "WBKPPLPP", "CITIPLPX", "INGBPLPW",
-      "DEUTPLPK", "DEUTPLP"}}
-
+      "DEUTPLPK", "DEUTPLP"}},
+    {BicCountry::United_States,
+     {"BOFAUS3N", "CITIUS33", "WELLSFARGO", "USBKUS44", "CHASUS33", "HSBCUS33", "PNCCUS33"}},
+    {BicCountry::United_Kingdom,
+     {"BARCGB22", "HSBCKENW", "LOYDGB21", "NWBKGB2L", "RBOSGB2L", "HSBCGB2L", "DEUTGB2L"}},
+    {BicCountry::Germany,
+     {"DEUTDEFF", "DRESDEFF", "COBADEFF", "BYLADEM1", "GENODEFF", "HYVEDEMM", "MALADE51", "NOLADE21", "SOLADEST",
+      "UNCRDEFF"}},
+    {BicCountry::Romania,
+     {"RNCBROBU", "BRDEROBU", "BTRLRO22", "PIRBROBU", "INGBROBU", "EXIMRO22", "CRDZROBU"}},
+    {BicCountry::France,
+     {"BNPAFRPP", "CEPAFRPP", "CRLYFRPP", "SOGEFRPP", "AGRIFRPP", "HSBDFRPP", "CCFRFRPP", "BNORDRPP", "CMCIFRPP"}},
+    {BicCountry::Italy,
+     {"UNCRITMM", "BCITITMM", "INTESA", "UBSPITPA", "BLOPIT22", "CITIITMX", "BNLIITRR"}},
+    {BicCountry::Spain,
+     {"CAIXESBB", "BBVAESMM", "SABSESBB", "BSCHESMM", "POPUESMM", "INGDESMM", "CITIES2X", "BCOEESMM"}},
+    {BicCountry::Netherlands,
+     {"ABNANL2A", "INGBNL2A", "RABONL2U", "TRIONL2U", "KNABNL2H", "SBINNL2X", "DEUTNL2N"}},
+    {BicCountry::India,
+     {"HDFCINBB", "ICICINBB", "SBININBB", "PNBAINBB", "UBININBB", "AXISINBB", "KKBKINBB", "YESBINBB", "IDBIINBB"}}
 };
 }


### PR DESCRIPTION
Added following countries to BIC in Finance. 
- US
- UK
- Germany
- Romania
- France
- Italy
- Spain
- Netherlands
- India

I don't think there was a way to have the test be under FinanceTest and still have it use `BicCountry` as the param. It's late, if it needs fixing please tell me and I'll fix it tomorrow.