### PR TITLE
update links for compilation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,5 @@ Please check [CONTRIBUTING](https://github.com/cieslarmichal/faker-cxx/blob/main
 
 ## 📝 Compilation guides
 
-- [Clang++](./docs/clang++_compilation_guide.md)
-- [Apple Clang++](./docs/apple_clang++_compilation_guide.md)
+- [Clang++](./docs/guides/clang++_compilation_guide.md)
+- [Apple Clang++](./docs/guides/apple_clang++_compilation_guide.md)


### PR DESCRIPTION
The current links for the guides in the read me result in 404 not found

![image](https://github.com/cieslarmichal/faker-cxx/assets/17298648/8d7fec15-0383-4483-ace5-cfe3470dc508)

Updated the links to fix this issue
