### PR TITLE
Add addresses in Brazil 🇧🇷

### DIFF
--- a/include/faker-cxx/types/AddressCountry.h
+++ b/include/faker-cxx/types/AddressCountry.h
@@ -21,6 +21,7 @@ namespace faker
         India,
         Denmark,
         Spain,
+        Brazil,
     };
 
     const std::vector<AddressCountry> addressCountries{
@@ -28,6 +29,7 @@ namespace faker
             AddressCountry::Russia, AddressCountry::Ukraine, AddressCountry::Italy,
             AddressCountry::Germany, AddressCountry::Czech,  AddressCountry::India,
             AddressCountry::Denmark, AddressCountry::Australia, AddressCountry::Spain,
+            AddressCountry::Brazil,
     };
 
     inline std::string toString(AddressCountry country)
@@ -37,7 +39,7 @@ namespace faker
                 {AddressCountry::Russia, "Russia"}, {AddressCountry::Ukraine, "Ukraine"}, {AddressCountry::Italy, "Italy"},
                 {AddressCountry::Germany, "Germany"}, {AddressCountry::Czech, "Czech"}, {AddressCountry::Australia, "Australia"},
                 {AddressCountry::India, "India"}, {AddressCountry::Denmark, "Denmark"},
-                {AddressCountry::Spain, "Spain"},
+                {AddressCountry::Spain, "Spain"}, {AddressCountry::Brazil, "Brazil"},
         };
 
         return countryToStringMapping.at(country);

--- a/src/modules/location/Location.cpp
+++ b/src/modules/location/Location.cpp
@@ -12,6 +12,7 @@
 #include "data/poland/PolandAddresses.h"
 #include "data/italy/ItalyAddresses.h"
 #include "data/russia/RussiaAddresses.h"
+#include "data/brazil/BrazilAddresses.h"
 #include "data/TimeZones.h"
 #include "data/ukraine/UkraineAddresses.h"
 #include "data/germany/GermanyAddresses.h"
@@ -34,6 +35,7 @@ namespace faker
                 {AddressCountry::Germany, germanyAddresses}, {AddressCountry::Czech, czechAddresses},
                 {AddressCountry::Australia, australiaAddresses}, {AddressCountry::India, indiaAddresses},
                 {AddressCountry::Denmark, denmarkAddresses}, {AddressCountry::Spain, spainAddresses},
+                {AddressCountry::Brazil, brazilAddresses}
         };
 
         const std::map<AddressCountry, Country> countryAddressToCountryMapping{
@@ -43,6 +45,7 @@ namespace faker
                 {AddressCountry::Germany, Country::Germany}, {AddressCountry::Czech, Country::Czech},
                 {AddressCountry::Australia, Country::Australia}, {AddressCountry::India, Country::India},
                 {AddressCountry::Denmark, Country::Denmark}, {AddressCountry::Spain, Country::Spain},
+                {AddressCountry::Brazil, Country::Brazil}
         };
     }
 
@@ -76,7 +79,19 @@ namespace faker
     {
         const auto& countryAddresses = countryToCountryAddressesMapping.at(country);
 
-        return Helper::arrayElement<std::string>(countryAddresses.cities);
+        const auto cityFormat = Helper::arrayElement<std::string>(countryAddresses.cityFormats);
+
+        const auto dataGeneratorsMapping = std::map<std::string, std::function<std::string()>>{
+                {"firstName", [&country]() { return Person::firstName(countryAddressToCountryMapping.at(country)); }},
+                {"lastName", [&country]() { return Person::lastName(countryAddressToCountryMapping.at(country)); }},
+                {"cityName",
+                              [&countryAddresses]() { return Helper::arrayElement<std::string>(countryAddresses.cities); }},
+                {"cityPrefix",
+                              [&countryAddresses]() { return Helper::arrayElement<std::string>(countryAddresses.cityPrefixes); }},
+                {"citySuffix",
+                              [&countryAddresses]() { return Helper::arrayElement<std::string>(countryAddresses.citySuffixes); }}};
+
+        return FormatHelper::fillTokenValues(cityFormat, dataGeneratorsMapping);
     }
 
     std::string Location::zipCode(AddressCountry country)

--- a/src/modules/location/LocationTest.cpp
+++ b/src/modules/location/LocationTest.cpp
@@ -9,6 +9,8 @@
 #include "../person/data/england/EnglishLastNames.h"
 #include "../person/data/spain/SpanishFirstNames.h"
 #include "../person/data/spain/SpanishLastNames.h"
+#include "../person/data/brazil/BrazilianFirstNames.h"
+#include "../person/data/brazil/BrazilianLastNames.h"
 #include "../person/data/russia/RussianFirstNames.h"
 #include "../person/data/russia/RussianLastNames.h"
 #include "../person/data/ukraine/UkrainianFirstNames.h"
@@ -32,6 +34,7 @@
 #include "data/india/IndiaAddresses.h"
 #include "data/denmark/DenmarkAddresses.h"
 #include "data/spain/SpainAddresses.h"
+#include "data/brazil/BrazilAddresses.h"
 
 using namespace ::testing;
 using namespace faker;
@@ -45,6 +48,7 @@ namespace
             {AddressCountry::Germany, germanyAddresses}, {AddressCountry::Czech, czechAddresses},
             {AddressCountry::Australia, australiaAddresses}, {AddressCountry::India, indiaAddresses},
             {AddressCountry::Denmark, denmarkAddresses}, {AddressCountry::Spain, spainAddresses},
+            {AddressCountry::Brazil, brazilAddresses}
     };
 
     const std::map<AddressCountry, std::string> generatedTestName{
@@ -60,6 +64,7 @@ namespace
             {AddressCountry::India, "shouldGenerateIndiaAddress"},
             {AddressCountry::Denmark, "shouldGenerateDenmarkAddress"},
             {AddressCountry::Spain, "shouldGenerateSpainAddress"},
+            {AddressCountry::Brazil, "shouldGenerateBrazilAddress"}
     };
 }
 
@@ -124,8 +129,29 @@ TEST_P(LocationTest, shouldGenerateCity)
 
     const auto generatedCity = Location::city(country);
 
-    ASSERT_TRUE(std::ranges::any_of(countryAddresses.cities,
-                                    [&generatedCity](const std::string& city) { return city == generatedCity; }));
+    if (country == faker::AddressCountry::Brazil)
+    {
+        const auto generatedCityElements = StringHelper::split(generatedCity, " ");
+
+        const auto& generatedCityPrefix = generatedCityElements[0];
+
+        std::vector<std::string> firstNames{brazilianMalesFirstNames};
+        firstNames.insert(firstNames.end(), brazilianFemalesFirstNames.begin(), brazilianFemalesFirstNames.end());
+
+        std::vector<std::string> lastNames{brazilianLastNames};
+
+        ASSERT_TRUE(std::ranges::any_of(firstNames,
+        [&generatedCityPrefix](const std::string& firstName) { return generatedCityPrefix.find(firstName) != std::string::npos; }) ||
+                    std::ranges::any_of(lastNames, 
+        [&generatedCityPrefix](const std::string& lastName) { return generatedCityPrefix.find(lastName) != std::string::npos; }) ||
+                    std::ranges::any_of(brazilCitySuffixes,
+        [&generatedCity](const std::string& citySuffix) { return generatedCity.find(citySuffix) != std::string::npos; }));
+        
+    } else 
+    {
+        ASSERT_TRUE(std::ranges::any_of(countryAddresses.cities,
+                                [&generatedCity](const std::string& city){ return city == generatedCity; }));
+    }
 }
 
 TEST_P(LocationTest, shouldGenerateZipCode)

--- a/src/modules/location/data/CountryAddresses.h
+++ b/src/modules/location/data/CountryAddresses.h
@@ -7,7 +7,6 @@ namespace faker
 {
 struct CountryAddresses
 {
-    std::vector<std::string> cities;
     std::string zipCodeFormat;
     std::vector<std::string> addressFormats;
     std::vector<std::string> secondaryAddressFormats;
@@ -16,6 +15,10 @@ struct CountryAddresses
     std::vector<std::string> streetNames;
     std::vector<std::string> streetSuffixes;
     std::vector<std::string> buildingNumberFormats;
+    std::vector<std::string> cityFormats;
+    std::vector<std::string> cityPrefixes;
+    std::vector<std::string> cities;
+    std::vector<std::string> citySuffixes;
     std::vector<std::string> states;
     std::vector<std::string> counties;
 };

--- a/src/modules/location/data/australia/AustraliaAddresses.h
+++ b/src/modules/location/data/australia/AustraliaAddresses.h
@@ -15,9 +15,9 @@ const std::vector<std::string> australiaBuildingNumberFormats{"####", "###", "##
 
 const std::vector<std::string> australiaStreetFormats{"{firstName} {streetSuffix}", "{lastName} {streetSuffix}"};
 
+const std::vector<std::string> australiaCityFormats{"{cityName}"};
 
-const CountryAddresses australiaAddresses{australiaCities,
-                                          australiaZipCodeFormat,
+const CountryAddresses australiaAddresses{australiaZipCodeFormat,
                                           australiaAddressFormats,
                                           {},
                                           australiaStreetFormats,
@@ -25,6 +25,10 @@ const CountryAddresses australiaAddresses{australiaCities,
                                           {},
                                           australiaStreetSuffixes,
                                           australiaBuildingNumberFormats,
+                                          australiaCityFormats,
+                                          {},
+                                          australiaCities,
+                                          {},
                                           australiaStates,
                                           {}};
 }

--- a/src/modules/location/data/brazil/BrazilAddresses.h
+++ b/src/modules/location/data/brazil/BrazilAddresses.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "../CountryAddresses.h"
+#include "BrazilCitySuffixes.h"
+#include "BrazilStreetSuffixes.h"
+#include "BrazilStates.h"
+
+namespace faker
+{
+const std::string brazilZipCodeFormat{"#####-###"};
+
+const std::vector<std::string> brazilAddressFormats{"{street} {buildingNumber}",
+                                                    "{street} {buildingNumber} {secondaryAddress}"};
+
+const std::vector<std::string> brazilSecondaryAddressFormats{"Apto. ###", "Sobrado ##", "Casa #", "Lote ##", "Quadra ##"};
+
+const std::vector<std::string> brazilBuildingNumberFormats{"#####", "####", "###"};
+
+const std::vector<std::string> brazilStreetFormats{"{firstName} {streetSuffix}", "{lastName} {streetSuffix}"};
+
+const std::vector<std::string> brazilCityFormats{"{firstName} {citySuffix}", "{lastName} {citySuffix}"};
+
+const CountryAddresses brazilAddresses{ brazilZipCodeFormat,
+                                        brazilAddressFormats,
+                                        brazilSecondaryAddressFormats,
+                                        brazilStreetFormats,
+                                        {},
+                                        {},
+                                        brazilStreetSuffixes,
+                                        brazilBuildingNumberFormats,
+                                        brazilCityFormats,
+                                        {},
+                                        {},
+                                        brazilCitySuffixes,
+                                        brazilStates,
+                                        {}};
+}

--- a/src/modules/location/data/brazil/BrazilCitySuffixes.h
+++ b/src/modules/location/data/brazil/BrazilCitySuffixes.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace faker
+{
+const std::vector<std::string> brazilCitySuffixes{
+  "do Descoberto", "de Nossa Senhora", "do Norte", "do Sul"
+};
+}

--- a/src/modules/location/data/brazil/BrazilStates.h
+++ b/src/modules/location/data/brazil/BrazilStates.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace faker
+{
+const std::vector<std::string> brazilStates = {
+  "Acre",
+  "Alagoas",
+  "Amapá",
+  "Amazonas",
+  "Bahia",
+  "Ceará",
+  "Distrito Federal",
+  "Espírito Santo",
+  "Goiás",
+  "Maranhão",
+  "Mato Grosso",
+  "Mato Grosso do Sul",
+  "Minas Gerais",
+  "Pará",
+  "Paraíba",
+  "Paraná",
+  "Pernambuco",
+  "Piauí",
+  "Rio de Janeiro",
+  "Rio Grande do Norte",
+  "Rio Grande do Sul",
+  "Rondônia",
+  "Roraima",
+  "Santa Catarina",
+  "São Paulo",
+  "Sergipe",
+  "Tocantins",
+};
+}

--- a/src/modules/location/data/brazil/BrazilStreetSuffixes.h
+++ b/src/modules/location/data/brazil/BrazilStreetSuffixes.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace faker
+{
+const std::vector<std::string> brazilStreetSuffixes{
+  "Rua", "Avenida", "Travessa", "Alameda", "Marginal", "Rodovia",
+};
+}

--- a/src/modules/location/data/czech/CzechAddresses.h
+++ b/src/modules/location/data/czech/CzechAddresses.h
@@ -19,8 +19,9 @@ const std::vector<std::string> czechBuildingNumberFormats{"#", "##", "###"};
 
 const std::vector<std::string> czechStreetFormats{"{streetName}"};
 
-const CountryAddresses czechAddresses{czechCities,
-                                      czechZipCodeFormat,
+const std::vector<std::string> czechCityFormats{"{cityName}"};
+
+const CountryAddresses czechAddresses{czechZipCodeFormat,
                                       czechAddressFormats,
                                       czechSecondaryAddressFormats,
                                       czechStreetFormats,
@@ -28,6 +29,10 @@ const CountryAddresses czechAddresses{czechCities,
                                       czechStreetNames,
                                       {},
                                       czechBuildingNumberFormats,
+                                      czechCityFormats,
+                                      {},
+                                      czechCities,
+                                      {},
                                       czechStates,
                                       {}};
 }

--- a/src/modules/location/data/denmark/DenmarkAddresses.h
+++ b/src/modules/location/data/denmark/DenmarkAddresses.h
@@ -6,25 +6,31 @@
 #include "DenmarkStreetNames.h"
 
 namespace faker {
-    const std::string denmarkZipCodeFormat{"####"};
 
-    const std::vector<std::string> denmarkAddressFormats{"{street} {buildingNumber}", "{street} {buildingNumber} {secondaryAddress}"};
+const std::string denmarkZipCodeFormat{"####"};
 
-    const std::vector<std::string> denmarkSecondaryAddressFormats{"#. tv", "#. th"};
+const std::vector<std::string> denmarkAddressFormats{"{street} {buildingNumber}", "{street} {buildingNumber} {secondaryAddress}"};
 
-    const std::vector<std::string> denmarkBuildingNumberFormats{"#", "##", "###", "##A", "##B"};
+const std::vector<std::string> denmarkSecondaryAddressFormats{"#. tv", "#. th"};
 
-    const std::vector<std::string> denmarkStreetFormats{"{streetName}"};
+const std::vector<std::string> denmarkBuildingNumberFormats{"#", "##", "###", "##A", "##B"};
 
-    const CountryAddresses denmarkAddresses{denmarkCities,
-                                            denmarkZipCodeFormat,
-                                            denmarkAddressFormats,
-                                            denmarkSecondaryAddressFormats,
-                                            denmarkStreetFormats,
-                                            {},
-                                            denmarkStreetNames,
-                                            {},
-                                            denmarkBuildingNumberFormats,
-                                            denmarkStates,
-                                            {}};
+const std::vector<std::string> denmarkStreetFormats{"{streetName}"};
+
+const std::vector<std::string> denmarkCityFormats{"{cityName}"};
+
+const CountryAddresses denmarkAddresses{denmarkZipCodeFormat,
+                                        denmarkAddressFormats,
+                                        denmarkSecondaryAddressFormats,
+                                        denmarkStreetFormats,
+                                        {},
+                                        denmarkStreetNames,
+                                        {},
+                                        denmarkBuildingNumberFormats,
+                                        denmarkCityFormats,
+                                        {},
+                                        denmarkCities,
+                                        {},
+                                        denmarkStates,
+                                        {}};
 }

--- a/src/modules/location/data/france/FranceAddresses.h
+++ b/src/modules/location/data/france/FranceAddresses.h
@@ -18,15 +18,20 @@ const std::vector<std::string> franceSecondaryAddressFormats{"Apt. ###", "Étage
 
 const std::vector<std::string> franceStreetFormats{"{streetPrefix} {streetSuffix}"};
 
-const CountryAddresses franceAddresses{franceCities,
-                                       franceZipCodeFormat,
-                                       franceAddressFormats,
-                                       franceSecondaryAddressFormats,
-                                       franceStreetFormats,
-                                       franceStreetPrefixes,
-                                       {},
-                                       franceStreetSuffixes,
-                                       franceBuildingNumberFormats,
-                                       franceStates,
-                                       {}};
+const std::vector<std::string> franceCityFormats{"{cityName}"};
+
+const CountryAddresses franceAddresses{ franceZipCodeFormat,
+                                        franceAddressFormats,
+                                        franceSecondaryAddressFormats,
+                                        franceStreetFormats,
+                                        franceStreetPrefixes,
+                                        {},
+                                        franceStreetSuffixes,
+                                        franceBuildingNumberFormats,
+                                        franceCityFormats,
+                                        {},
+                                        franceCities,
+                                        {},
+                                        franceStates,
+                                        {}};
 }

--- a/src/modules/location/data/germany/GermanyAddresses.h
+++ b/src/modules/location/data/germany/GermanyAddresses.h
@@ -18,8 +18,9 @@ const std::vector<std::string> germanyBuildingNumberFormats{"###", "##", "#", "#
 
 const std::vector<std::string> germanyStreetFormats{"{streetName}"};
 
-const CountryAddresses germanyAddresses{germanyCities,
-                                        germanyZipCodeFormat,
+const std::vector<std::string> germanyCityFormats{"{cityName}"};
+
+const CountryAddresses germanyAddresses{germanyZipCodeFormat,
                                         germanyAddressFormats,
                                         germanySecondaryAddressFormats,
                                         germanyStreetFormats,
@@ -27,6 +28,10 @@ const CountryAddresses germanyAddresses{germanyCities,
                                         germanyStreetNames,
                                         {},
                                         germanyBuildingNumberFormats,
+                                        germanyCityFormats,
+                                        {},
+                                        germanyCities,
+                                        {},
                                         germanyStates,
                                         {}};
 }

--- a/src/modules/location/data/india/IndiaAddresses.h
+++ b/src/modules/location/data/india/IndiaAddresses.h
@@ -6,25 +6,30 @@
 #include "IndiaStates.h"
 
 namespace faker {
-    const std::string indiaZipCodeFormat{"######"};
+const std::string indiaZipCodeFormat{"######"};
 
-    const std::vector<std::string> indiaAddressFormats{"{buildingNumber} {street}"};
+const std::vector<std::string> indiaAddressFormats{"{buildingNumber} {street}"};
 
-    const std::vector<std::string> indiaSecondaryAddressFormats{"Apt. ###", "Flat ###"};
+const std::vector<std::string> indiaSecondaryAddressFormats{"Apt. ###", "Flat ###"};
 
-    const std::vector<std::string> indiaBuildingNumberFormats{"#####", "####", "###"};
+const std::vector<std::string> indiaBuildingNumberFormats{"#####", "####", "###"};
 
-    const std::vector<std::string> indiaStreetFormats{"{firstName} {streetSuffix}", "{lastName} {streetSuffix}"};
+const std::vector<std::string> indiaStreetFormats{"{firstName} {streetSuffix}", "{lastName} {streetSuffix}"};
 
-    const CountryAddresses indiaAddresses{indiaCities,
-                                          indiaZipCodeFormat,
-                                          indiaAddressFormats,
-                                          indiaSecondaryAddressFormats,
-                                          indiaStreetFormats,
-                                          {},
-                                          {},
-                                          indiaStreetSuffixes,
-                                          indiaBuildingNumberFormats,
-                                          indiaStates,
-                                          {}};
+const std::vector<std::string> indiaCityFormats{"{cityName}"};
+
+const CountryAddresses indiaAddresses{  indiaZipCodeFormat,
+                                        indiaAddressFormats,
+                                        indiaSecondaryAddressFormats,
+                                        indiaStreetFormats,
+                                        {},
+                                        {},
+                                        indiaStreetSuffixes,
+                                        indiaBuildingNumberFormats,
+                                        indiaCityFormats,
+                                        {},
+                                        indiaCities,
+                                        {},
+                                        indiaStates,
+                                        {}};
 }

--- a/src/modules/location/data/italy/ItalyAddresses.h
+++ b/src/modules/location/data/italy/ItalyAddresses.h
@@ -18,8 +18,9 @@ const std::vector<std::string> italyBuildingNumberFormats{"###", "##", "#"};
 
 const std::vector<std::string> italyStreetFormats{"{streetPrefix} {firstName}", "{streetPrefix} {lastName}"};
 
-const CountryAddresses italyAddresses{italyCities,
-                                      italyZipCodeFormat,
+const std::vector<std::string> italyCityFormats{"{cityName}"};
+
+const CountryAddresses italyAddresses{italyZipCodeFormat,
                                       italyAddressFormats,
                                       italySecondaryAddressFormats,
                                       italyStreetFormats,
@@ -27,6 +28,10 @@ const CountryAddresses italyAddresses{italyCities,
                                       {},
                                       {},
                                       italyBuildingNumberFormats,
+                                      italyCityFormats,
+                                      {},
+                                      italyCities,
+                                      {},
                                       italyStates,
                                       {}};
 }

--- a/src/modules/location/data/poland/PolandAddresses.h
+++ b/src/modules/location/data/poland/PolandAddresses.h
@@ -20,15 +20,20 @@ const std::vector<std::string> polandBuildingNumberFormats{"#", "##", "###"};
 
 const std::vector<std::string> polandStreetFormats{"{streetPrefix} {streetName}"};
 
-const CountryAddresses polandAddresses{polandCities,
-                                       polandZipCodeFormat,
-                                       polandAddressFormats,
-                                       polandSecondaryAddressFormats,
-                                       polandStreetFormats,
-                                       polandStreetPrefixes,
-                                       polandStreetNames,
-                                       {},
-                                       polandBuildingNumberFormats,
-                                       polandStates,
-                                       {}};
+const std::vector<std::string> polandCityFormats{"{cityName}"};
+
+const CountryAddresses polandAddresses{ polandZipCodeFormat,
+                                        polandAddressFormats,
+                                        polandSecondaryAddressFormats,
+                                        polandStreetFormats,
+                                        polandStreetPrefixes,
+                                        polandStreetNames,
+                                        {},
+                                        polandBuildingNumberFormats,
+                                        polandCityFormats,
+                                        {},
+                                        polandCities,
+                                        {},
+                                        polandStates,
+                                        {}};
 }

--- a/src/modules/location/data/russia/RussiaAddresses.h
+++ b/src/modules/location/data/russia/RussiaAddresses.h
@@ -20,15 +20,20 @@ const std::vector<std::string> russiaBuildingNumberFormats{"#", "##", "###"};
 const std::vector<std::string> russiaStreetFormats{"{streetPrefix} {firstName}", "{streetPrefix} {lastName}",
                                                    "{streetPrefix} {streetName}"};
 
-const CountryAddresses russiaAddresses{russiaCities,
-                                       russiaZipCodeFormat,
-                                       russiaAddressFormats,
-                                       russiaSecondaryAddressFormats,
-                                       russiaStreetFormats,
-                                       russiaStreetPrefixes,
-                                       russiaStreetNames,
-                                       {},
-                                       russiaBuildingNumberFormats,
-                                       russiaStates,
-                                       {}};
+const std::vector<std::string> russiaCityFormats{"{cityName}"};
+
+const CountryAddresses russiaAddresses{ russiaZipCodeFormat,
+                                        russiaAddressFormats,
+                                        russiaSecondaryAddressFormats,
+                                        russiaStreetFormats,
+                                        russiaStreetPrefixes,
+                                        russiaStreetNames,
+                                        {},
+                                        russiaBuildingNumberFormats,
+                                        russiaCityFormats,
+                                        {},
+                                        russiaCities,
+                                        {},
+                                        russiaStates,
+                                        {}};
 }

--- a/src/modules/location/data/spain/SpainAddresses.h
+++ b/src/modules/location/data/spain/SpainAddresses.h
@@ -19,8 +19,9 @@ const std::vector<std::string> spainBuildingNumberFormats{"s/n.", "#", "##"};
 
 const std::vector<std::string> spainStreetFormats{"{streetSuffix} {firstName}", "{streetSuffix} {firstName} {lastName}"};
 
-const CountryAddresses spainAddresses{spainCities,
-                                      spainZipCodeFormat,
+const std::vector<std::string> spainCityFormats{"{cityName}"};
+
+const CountryAddresses spainAddresses{spainZipCodeFormat,
                                       spainAddressFormats,
                                       spainSecondaryAddressFormats,
                                       spainStreetFormats,
@@ -28,6 +29,10 @@ const CountryAddresses spainAddresses{spainCities,
                                       {},
                                       spainStreetSuffixes,
                                       spainBuildingNumberFormats,
+                                      spainCityFormats,
+                                      {},
+                                      spainCities,
+                                      {},
                                       spainStates,
                                       spainCounties};
 }

--- a/src/modules/location/data/ukraine/UkraineAddresses.h
+++ b/src/modules/location/data/ukraine/UkraineAddresses.h
@@ -20,8 +20,9 @@ const std::vector<std::string> ukraineBuildingNumberFormats{"#", "##", "###"};
 const std::vector<std::string> ukraineStreetFormats{"{streetPrefix} {firstName}", "{streetPrefix} {lastName}",
                                                     "{streetPrefix} {streetName}"};
 
-const CountryAddresses ukraineAddresses{ukraineCities,
-                                        ukraineZipCodeFormat,
+const std::vector<std::string> ukraineCityFormats{"{cityName}"};
+
+const CountryAddresses ukraineAddresses{ukraineZipCodeFormat,
                                         ukraineAddressFormats,
                                         ukraineSecondaryAddressFormats,
                                         ukraineStreetFormats,
@@ -29,6 +30,10 @@ const CountryAddresses ukraineAddresses{ukraineCities,
                                         ukraineStreetNames,
                                         {},
                                         ukraineBuildingNumberFormats,
+                                        ukraineCityFormats,
+                                        {},
+                                        ukraineCities,
+                                        {},
                                         ukraineStates,
                                         {}};
 }

--- a/src/modules/location/data/usa/UsaAddresses.h
+++ b/src/modules/location/data/usa/UsaAddresses.h
@@ -17,8 +17,9 @@ const std::vector<std::string> usaBuildingNumberFormats{"#####", "####", "###"};
 
 const std::vector<std::string> usaStreetFormats{"{firstName} {streetSuffix}", "{lastName} {streetSuffix}"};
 
-const CountryAddresses usaAddresses{usaCities,
-                                    usaZipCodeFormat,
+const std::vector<std::string> usaCityFormats{"{cityName}"};
+
+const CountryAddresses usaAddresses{usaZipCodeFormat,
                                     usaAddressFormats,
                                     usaSecondaryAddressFormats,
                                     usaStreetFormats,
@@ -26,6 +27,10 @@ const CountryAddresses usaAddresses{usaCities,
                                     {},
                                     usaStreetSuffixes,
                                     usaBuildingNumberFormats,
+                                    usaCityFormats,
+                                    {},
+                                    usaCities,
+                                    {},
                                     usaStates,
                                     {}};
 }


### PR DESCRIPTION
The PR:
- Added location address data from Brazil #146.
- Added corresponding tests.
- Added `cityFormats`, `cityPrefixes`, and `citySuffixes` fields for `CountryAddresses`, modified other countries.

PR passed all the tests in my local.

Data is taken from [faker-js](https://github.com/faker-js/faker/tree/next/src/locales/pt_BR/location).