### PR TITLE
Added areaCode function to Phone module

### DIFF
--- a/include/faker-cxx/Phone.h
+++ b/include/faker-cxx/Phone.h
@@ -83,6 +83,8 @@ public:
      */
     static std::string imei();
 
+    static std::string areaCode(const std::string& phoneNumber);
+
 private:
     static std::map<PhoneNumberCountryFormat, std::string> createPhoneNumberFormatMap();
     static std::map<PhoneNumberCountryFormat, std::string> phoneNumberFormatMap;

--- a/src/modules/phone/Phone.cpp
+++ b/src/modules/phone/Phone.cpp
@@ -73,4 +73,29 @@ std::map<PhoneNumberCountryFormat, std::string> Phone::createPhoneNumberFormatMa
 
     return formatMap;
 }
+
+// New areaCode function
+std::string Phone::areaCode(const std::string& phoneNumber)
+{
+    //assuming country codes always start with "+"
+    std::string countryCode = "+";
+    bool plusFound = false;
+
+    for(char ch : phoneNumber){
+        if (ch == '+'){
+            plusFound = true;
+            //skip the '+' sign but mark it as found
+            continue;
+        }
+        if (plusFound && std::isdigit(ch)){
+            countryCode += ch;
+        }
+        else if (plusFound && !std::isdigit(ch)){
+            //stop if a non-digit character is found after finding "+"
+            break;
+        }
+    }
+
+    //returns an empty string if no country code is found, otherwise return the country code
+    return countryCode == "+" ? "" : countryCode;
 }

--- a/src/modules/phone/PhoneTest.cpp
+++ b/src/modules/phone/PhoneTest.cpp
@@ -92,3 +92,18 @@ TEST_F(PhoneTest, ManufacturerGeneration)
                                     [generatedManufacturer](const std::string& manufacturer)
                                     { return manufacturer == generatedManufacturer; }));
 }
+
+TEST_F(PhoneTest, AreaCodeExtraction){
+    for(const auto& phoneNumber : faker::phoneNumbers){
+        std::string extracedAreCode = Phone::areaCode(phoneNumber);
+
+        //Verify that the rxtracted area code starts with a '+' and is followed by digits only
+        if(!extractedAreaCode.empty()){
+            EXPECT_EQ(extractedAreaCode[0], '+');
+
+            for(size_t i = 1; i < extractedAreaCode.size(); i++){
+                EXPECT_TRUE(std::isdigit(extractedAreaCode[i])) << "Failed at phone number: " << phoneNumber;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added the areaCode function which extracts the country code from a phone number, assuming the valid code immediately follows the first + sign in the string. It captures a sequence of digits as the country code until a non-digit character is encountered, ignoring any additional + signs or digits thereafter, and returns the country code with a leading + or an empty string if no valid code is found.