### PR TITLE
Added areaCode function to Phone module

### DIFF
--- a/include/faker-cxx/Phone.h
+++ b/include/faker-cxx/Phone.h
@@ -83,6 +83,8 @@ public:
      */
     static std::string imei();
 
+    static std::string areaCode(const std::string& phoneNumber);
+
 private:
     static std::map<PhoneNumberCountryFormat, std::string> createPhoneNumberFormatMap();
     static std::map<PhoneNumberCountryFormat, std::string> phoneNumberFormatMap;

--- a/src/modules/phone/Phone.cpp
+++ b/src/modules/phone/Phone.cpp
@@ -99,3 +99,4 @@ std::string Phone::areaCode(const std::string& phoneNumber)
     //returns an empty string if no country code is found, otherwise return the country code
     return countryCode == "+" ? "" : countryCode;
 }
+}

--- a/src/modules/phone/Phone.cpp
+++ b/src/modules/phone/Phone.cpp
@@ -73,4 +73,29 @@ std::map<PhoneNumberCountryFormat, std::string> Phone::createPhoneNumberFormatMa
 
     return formatMap;
 }
+
+// New areaCode function
+std::string Phone::areaCode(const std::string& phoneNumber)
+{
+    //assuming country codes always start with "+"
+    std::string countryCode = "+";
+    bool plusFound = false;
+
+    for(char ch : phoneNumber){
+        if (ch == '+'){
+            plusFound = true;
+            //skip the '+' sign but mark it as found
+            continue;
+        }
+        if (plusFound && std::isdigit(ch)){
+            countryCode += ch;
+        }
+        else if (plusFound && !std::isdigit(ch)){
+            //stop if a non-digit character is found after finding "+"
+            break;
+        }
+    }
+
+    //returns an empty string if no country code is found, otherwise return the country code
+    return countryCode == "+" ? "" : countryCode;
 }

--- a/src/modules/phone/PhoneTest.cpp
+++ b/src/modules/phone/PhoneTest.cpp
@@ -93,17 +93,41 @@ TEST_F(PhoneTest, ManufacturerGeneration)
                                     { return manufacturer == generatedManufacturer; }));
 }
 
-TEST_F(PhoneTest, AreaCodeExtraction){
-    for(const auto& phoneNumber : faker::phoneNumbers){
-        std::string extractedAreaCode = Phone::areaCode(phoneNumber);
+TEST_F(PhoneTest, AreaCodeExtraction)
+{
+    // Test with a valid phone number including country code
+    std::string phoneNumberWithCountryCode = "+1234567890";
+    std::string expectedCountryCode = "+1";
+    std::string actualCountryCode = Phone::areaCode(phoneNumberWithCountryCode);
+    ASSERT_EQ(expectedCountryCode, actualCountryCode);
 
-        //Verify that the extracted area code starts with a '+' and is followed by digits only
-        if(!extractedAreaCode.empty()){
-            EXPECT_EQ(extractedAreaCode[0], '+');
+    // Test with a phone number without country code
+    std::string phoneNumberWithoutCountryCode = "1234567890";
+    std::string expectedNoCountryCode = "";
+    actualCountryCode = Phone::areaCode(phoneNumberWithoutCountryCode);
+    ASSERT_EQ(expectedNoCountryCode, actualCountryCode);
 
-            for(size_t i = 1; i < extractedAreaCode.size(); i++){
-                EXPECT_TRUE(std::isdigit(extractedAreaCode[i])) << "Failed at phone number: " << phoneNumber;
-            }
-        }
-    }
+    // Test with a phone number that includes non-digit characters immediately after "+"
+    std::string phoneNumberWithNonDigitAfterPlus = "+1-234567890";
+    expectedCountryCode = "+1";
+    actualCountryCode = Phone::areaCode(phoneNumberWithNonDigitAfterPlus);
+    ASSERT_EQ(expectedCountryCode, actualCountryCode);
+
+    // Test with an empty string
+    std::string emptyPhoneNumber = "";
+    expectedNoCountryCode = "";
+    actualCountryCode = Phone::areaCode(emptyPhoneNumber);
+    ASSERT_EQ(expectedNoCountryCode, actualCountryCode);
+
+    // Test with a phone number that starts with "+" but followed by non-digits
+    std::string phoneNumberWithPlusAndNonDigits = "+abcdefg";
+    expectedNoCountryCode = "";
+    actualCountryCode = Phone::areaCode(phoneNumberWithPlusAndNonDigits);
+    ASSERT_EQ(expectedNoCountryCode, actualCountryCode);
+
+    // Test with a phone number that has "+" not at the beginning
+    std::string phoneNumberWithPlusNotAtStart = "123+4567890";
+    expectedNoCountryCode = "";
+    actualCountryCode = Phone::areaCode(phoneNumberWithPlusNotAtStart);
+    ASSERT_EQ(expectedNoCountryCode, actualCountryCode);
 }

--- a/src/modules/phone/PhoneTest.cpp
+++ b/src/modules/phone/PhoneTest.cpp
@@ -95,9 +95,9 @@ TEST_F(PhoneTest, ManufacturerGeneration)
 
 TEST_F(PhoneTest, AreaCodeExtraction){
     for(const auto& phoneNumber : faker::phoneNumbers){
-        std::string extracedAreCode = Phone::areaCode(phoneNumber);
+        std::string extractedAreaCode = Phone::areaCode(phoneNumber);
 
-        //Verify that the rxtracted area code starts with a '+' and is followed by digits only
+        //Verify that the extracted area code starts with a '+' and is followed by digits only
         if(!extractedAreaCode.empty()){
             EXPECT_EQ(extractedAreaCode[0], '+');
 

--- a/src/modules/phone/PhoneTest.cpp
+++ b/src/modules/phone/PhoneTest.cpp
@@ -92,3 +92,18 @@ TEST_F(PhoneTest, ManufacturerGeneration)
                                     [generatedManufacturer](const std::string& manufacturer)
                                     { return manufacturer == generatedManufacturer; }));
 }
+
+TEST_F(PhoneTest, AreaCodeExtraction){
+    for(const auto& phoneNumber : faker::phoneNumbers){
+        std::string extracedAreCode = Phone::areaCode(phoneNumber);
+
+        //Verify that the rxtracted area code starts with a '+' and is followed by digits only
+        if(!extractedAreaCode.empty()){
+            EXPECT_EQ(extractedAreaCode[0], '+');
+
+            for(size_t i = 1; i < extractedAreaCode.size(); i++){
+                EXPECT_TRUE(std::isdigit(extractedAreaCode[i])) << "Failed at phone number: " << phoneNumber;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added the areaCode function which extracts the country code from a phone number, assuming the valid code immediately follows the first + sign in the string. It captures a sequence of digits as the country code until a non-digit character is encountered, ignoring any additional + signs or digits thereafter, and returns the country code with a leading + or an empty string if no valid code is found.