### PR TITLE
Feature/anonymous username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ build-linux-clang
 .cache/
 #vim swap files
 *.sw?
+
+#kdevelop temp files
+*.kdev4
+.kdev4

--- a/include/faker-cxx/Internet.h
+++ b/include/faker-cxx/Internet.h
@@ -321,5 +321,18 @@ public:
      * @endcode
      */
     static std::string domainSuffix();
+
+    /**
+     * @brief Generates a random username.
+     *
+     * @param maxLength maxLength of the generated username.
+     *
+     * @return Username.
+     *
+     * @code
+     * Internet::anonymousUsername() // "profusebrother", "richad", "powerfuldifferential"
+     * @endcode
+     */
+    static std::string anonymousUsername(unsigned maxLength);
 };
 }

--- a/src/modules/internet/Internet.cpp
+++ b/src/modules/internet/Internet.cpp
@@ -320,4 +320,26 @@ std::string Internet::domainSuffix()
     return Helper::arrayElement<std::string>(domainSuffixes);
 }
 
+std::string Internet::anonymousUsername(unsigned maxLength)
+{
+    unsigned defaultMin = 6;
+    unsigned defaultMax = 20;
+
+    if (maxLength < defaultMin)
+        maxLength = defaultMin;
+    else if (maxLength > defaultMax)
+        maxLength = defaultMax;
+
+    unsigned adjectiveLength = Number::integer<unsigned>(2, 1 + maxLength/2);
+    unsigned nounLength = maxLength - adjectiveLength;
+
+    std::string adjective = Word::adjective(adjectiveLength);
+    std::string noun = Word::noun(nounLength);
+
+    std::stringstream usernameBuilder;
+    usernameBuilder << adjective << noun;
+
+    return usernameBuilder.str();
+}
+
 }

--- a/src/modules/internet/Internet.cpp
+++ b/src/modules/internet/Internet.cpp
@@ -335,25 +335,6 @@ std::string Internet::anonymousUsername(unsigned maxLength)
     std::stringstream usernameBuilder;
 
     usernameBuilder << Word::adjective(adjectiveLength) << Word::noun(nounLength);
-    // while (true)
-    // {
-    //     std::string adjective = Word::adjective(adjectiveLength);
-    //     if (adjectiveLength == adjective.length())
-    //     {
-    //         usernameBuilder << adjective;
-    //         break;
-    //     }
-    // }
-    //
-    // while (true)
-    // {
-    //     std::string noun = Word::noun(nounLength);
-    //     if (nounLength == noun.length())
-    //     {
-    //         usernameBuilder << noun;
-    //         break;
-    //     }
-    // }
 
     return usernameBuilder.str();
 }

--- a/src/modules/internet/Internet.cpp
+++ b/src/modules/internet/Internet.cpp
@@ -330,14 +330,29 @@ std::string Internet::anonymousUsername(unsigned maxLength)
     else if (maxLength > defaultMax)
         maxLength = defaultMax;
 
-    unsigned adjectiveLength = Number::integer<unsigned>(2, 1 + maxLength/2);
+    unsigned adjectiveLength = Number::integer<unsigned>(3, 1 + maxLength/2);
     unsigned nounLength = maxLength - adjectiveLength;
-
-    std::string adjective = Word::adjective(adjectiveLength);
-    std::string noun = Word::noun(nounLength);
-
     std::stringstream usernameBuilder;
-    usernameBuilder << adjective << noun;
+
+    while (true)
+    {
+        std::string adjective = Word::adjective(adjectiveLength);
+        if (adjectiveLength == adjective.length())
+        {
+            usernameBuilder << adjective;
+            break;
+        }
+    }
+
+    while (true)
+    {
+        std::string noun = Word::noun(nounLength);
+        if (nounLength == noun.length())
+        {
+            usernameBuilder << noun;
+            break;
+        }
+    }
 
     return usernameBuilder.str();
 }

--- a/src/modules/internet/Internet.cpp
+++ b/src/modules/internet/Internet.cpp
@@ -334,25 +334,26 @@ std::string Internet::anonymousUsername(unsigned maxLength)
     unsigned nounLength = maxLength - adjectiveLength;
     std::stringstream usernameBuilder;
 
-    while (true)
-    {
-        std::string adjective = Word::adjective(adjectiveLength);
-        if (adjectiveLength == adjective.length())
-        {
-            usernameBuilder << adjective;
-            break;
-        }
-    }
-
-    while (true)
-    {
-        std::string noun = Word::noun(nounLength);
-        if (nounLength == noun.length())
-        {
-            usernameBuilder << noun;
-            break;
-        }
-    }
+    usernameBuilder << Word::adjective(adjectiveLength) << Word::noun(nounLength);
+    // while (true)
+    // {
+    //     std::string adjective = Word::adjective(adjectiveLength);
+    //     if (adjectiveLength == adjective.length())
+    //     {
+    //         usernameBuilder << adjective;
+    //         break;
+    //     }
+    // }
+    //
+    // while (true)
+    // {
+    //     std::string noun = Word::noun(nounLength);
+    //     if (nounLength == noun.length())
+    //     {
+    //         usernameBuilder << noun;
+    //         break;
+    //     }
+    // }
 
     return usernameBuilder.str();
 }

--- a/src/modules/internet/InternetTest.cpp
+++ b/src/modules/internet/InternetTest.cpp
@@ -1,4 +1,5 @@
 #include "faker-cxx/Internet.h"
+#include "faker-cxx/Number.h"
 
 #include <algorithm>
 #include <array>
@@ -744,4 +745,31 @@ TEST_F(InternetTest, shouldGeneratePort)
 
     ASSERT_GE(generatedPort, 0);
     ASSERT_LE(generatedPort, 65535);
+}
+
+TEST_F(InternetTest, shouldGenerateAnonymousUsername)
+{
+    for (int i = 0; i < 100; i++)
+    {
+        const auto maxLength = Number::integer<unsigned>(6, 20);
+        const auto generatedUsername = Internet::anonymousUsername(maxLength);
+
+        ASSERT_EQ(generatedUsername.length(), maxLength);
+    }
+}
+
+TEST_F(InternetTest, shouldGenerateAnonymousUsernameWithMinLength)
+{
+    const auto maxLength = 5;
+    const auto generatedUsername = Internet::anonymousUsername(maxLength);
+
+    ASSERT_EQ(generatedUsername.length(), 6);
+}
+
+TEST_F(InternetTest, shouldGenerateAnonymousUsernameWithMaxLength)
+{
+    const auto maxLength = 21;
+    const auto generatedUsername = Internet::anonymousUsername(maxLength);
+
+    ASSERT_EQ(generatedUsername.length(), 20);
 }


### PR DESCRIPTION
Added a new method `anonymousUsername` that generates the username of length [6,20] characters. It uses `Words` module to get the adjective for the first half of the username and then uses the nouns collection to generate the next half.

Added tests to ensure that the method returns the requested username with specified length.

This method resolves #466 