### PR TITLE
fixed Date::time formatting

### DIFF
--- a/src/modules/date/Date.cpp
+++ b/src/modules/date/Date.cpp
@@ -182,7 +182,7 @@ unsigned int Date::second()
 
 std::string Date::time()
 {
-    return FormatHelper::format("{}:{}", Date::hour(), Date::minute());
+    return FormatHelper::format("{:02}:{:02}", Date::hour(), Date::minute());
 }
 
 unsigned int Date::dayOfMonth()

--- a/src/modules/date/DateTest.cpp
+++ b/src/modules/date/DateTest.cpp
@@ -333,6 +333,9 @@ TEST_F(DateTest, shouldGenerateRandomTime)
 
     ASSERT_EQ(generatedTimeParts.size(), 2);
 
+    ASSERT_EQ(generatedTimeParts[0].length(), 2);
+    ASSERT_EQ(generatedTimeParts[1].length(), 2);
+
     const auto& hour = atoi(generatedTimeParts[0].c_str());
     const auto& minute = atoi(generatedTimeParts[1].c_str());
 


### PR DESCRIPTION
Fixed Date::time() method to use {:02} formatting for standard 2-digit (24h) time format, added unit test for testing against length of string