### PR TITLE
Issue534 macos14 workflow upversion

### DIFF
--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
   pull_request:
 
 env:

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
   pull_request:
 
 env:

--- a/.github/workflows/macos-clang-build.yml
+++ b/.github/workflows/macos-clang-build.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cmake -B ${{github.workspace}}/build \
             -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@16/bin/clang++
+            -DCMAKE_CXX_COMPILER=clang++
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/macos-clang-build.yml
+++ b/.github/workflows/macos-clang-build.yml
@@ -11,11 +11,11 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Install clang
-        run: brew install llvm@16 && echo 'export PATH="/usr/local/opt/llvm@16/bin:$PATH"' >> /Users/runner/.bash_profile && source /Users/runner/.bash_profile && which clang++
+        run: brew install llvm@16 && echo 'export PATH="/opt/homebrew/opt/llvm@16/bin:$PATH"' >> /Users/runner/.bash_profile && source /Users/runner/.bash_profile && which clang++
         
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/macos-clang-build.yml
+++ b/.github/workflows/macos-clang-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
   pull_request:
 
 env:

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
   pull_request:
 
 env:


### PR DESCRIPTION
Referring to issue: https://github.com/cieslarmichal/faker-cxx/issues/534
I've pinned the macos runner version to use macos-14 instead of macos-latest to avoid future incompatibilities. Refer to this page for runner update notes: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

Changes:
- Add workflow_dispatch to be able to manually test these workflows
- Use `clang++` instead of the full clang++ path when configuring CMAKE.
- Brew installed clang++ to a different path, so updated that

The macos workflow sets up the clang++ path, and CMAKE is configured correctly here: https://github.com/AdamJovanovic/faker-cxx/actions/runs/8994676880/job/24708486690
