### PR TITLE
Use CMake to detect if std format is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,13 @@ project(${PROJECT_NAME} CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(CheckIncludeFileCXX)
+CHECK_INCLUDE_FILE_CXX("format" HAS_STD_FORMAT)
+
 option(BUILD_FAKER_TESTS DEFAULT ON)
 
 if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20 /permissive- /bigobj")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /bigobj")
 else ()
     set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wconversion -Wformat -Werror"
@@ -127,9 +130,9 @@ install(EXPORT ${LIBRARY_NAME}-targets
     FILE ${LIBRARY_NAME}-config.cmake
     DESTINATION lib/cmake/${LIBRARY_NAME})
 
-if (APPLE OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
-    VERSION_LESS 12))
-
+if (HAS_STD_FORMAT)
+    target_compile_definitions(${LIBRARY_NAME} PRIVATE HAS_STD_FORMAT)
+else ()
     add_subdirectory(externals/fmt)
     set(FMT_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/externals/fmt/include")
     target_link_libraries(${LIBRARY_NAME} PRIVATE fmt)
@@ -159,7 +162,7 @@ if (BUILD_FAKER_TESTS)
     if (APPLE OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
         AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12))
 
-        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE fmt)
+        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE $<$<NOT:$<BOOL:${HAS_STD_FORMAT}>>:fmt>)
         target_include_directories(
             ${LIBRARY_NAME}-UT
             PRIVATE ${FMT_INCLUDE_DIR} ${GTEST_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ cmake_minimum_required(VERSION 3.22)
 set(PROJECT_NAME faker-cxx)
 project(${PROJECT_NAME} CXX)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(BUILD_FAKER_TESTS DEFAULT ON)
@@ -109,6 +107,8 @@ target_include_directories(
     ${LIBRARY_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
+
+target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_20)
 
 install(TARGETS ${LIBRARY_NAME}
     EXPORT ${LIBRARY_NAME}-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@ project(${PROJECT_NAME} CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(CheckIncludeFileCXX)
-CHECK_INCLUDE_FILE_CXX("format" HAS_STD_FORMAT)
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_FLAGS -std=c++20)
+check_cxx_source_compiles("#include <format>\nint main(){ auto var = std::format(\"{}\", \"Hello\"); return 0; }" HAS_STD_FORMAT)
 
 option(BUILD_FAKER_TESTS DEFAULT ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,19 +159,18 @@ if (BUILD_FAKER_TESTS)
     target_link_libraries(${LIBRARY_NAME}-UT PRIVATE gtest_main gmock_main
         faker-cxx)
 
-    if (APPLE OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12))
-
-        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE $<$<NOT:$<BOOL:${HAS_STD_FORMAT}>>:fmt>)
-        target_include_directories(
-            ${LIBRARY_NAME}-UT
-            PRIVATE ${FMT_INCLUDE_DIR} ${GTEST_INCLUDE_DIR}
-            ${GMOCK_INCLUDE_DIR} ${CMAKE_CURRENT_LIST_DIR})
-    else ()
+    if (HAS_STD_FORMAT)
         target_include_directories(
             ${LIBRARY_NAME}-UT
             PRIVATE ${GTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR}
             ${CMAKE_CURRENT_LIST_DIR})
+        target_compile_definitions(${LIBRARY_NAME}-UT PRIVATE HAS_STD_FORMAT)
+    else ()
+        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE fmt)
+        target_include_directories(
+            ${LIBRARY_NAME}-UT
+            PRIVATE ${FMT_INCLUDE_DIR} ${GTEST_INCLUDE_DIR}
+            ${GMOCK_INCLUDE_DIR} ${CMAKE_CURRENT_LIST_DIR})
     endif ()
 
     add_test(

--- a/src/common/FormatHelper.h
+++ b/src/common/FormatHelper.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#if defined(__APPLE__) ||  (defined(__GNUC__) && (__GNUC__ < 12) && !defined(__clang__))
+#if !defined(HAS_STD_FORMAT)
 #include <fmt/format.h>
 #else
 #include <format>
@@ -16,7 +16,7 @@ namespace faker
 class FormatHelper
 {
 public:
-#if defined(__APPLE__) || (defined(__GNUC__) && (__GNUC__ < 12) && !defined(__clang__))
+#if !defined(HAS_STD_FORMAT)
     template <typename... Args>
     static std::string format(fmt::format_string<Args...> fmt, Args&&... args)
     {


### PR DESCRIPTION
This PR changes the way how std::format is consumed, instead of setting a specific compiler version in CMake, it uses [CheckIncludeFileCXX](https://cmake.org/cmake/help/latest/module/CheckIncludeFileCXX.html) to detect if format can be imported from system (the compiler is configured already). In case finding `#include <format>` available, CMake will define `HAS_STD_FORMAT` and this variable will be used to define the logic of using libfmt or std format.

The advantage here is keeping the feature compiler agnostic, so in case the compiler X supports std format already, it will be used by default always. 

Second, the logic is centralized, CMake will check and define the state, so the header c++ has no double check for compiler version, etc.

I also replaced `CMAKE_CXX_STANDARD` by `target_compile_features` to indicate about C++20 be needed by the target only (public, so tests will use C++20 too). This replacement gives the option of overriding the definition with newer C++ standard like C++23 via CMake definition.

fixes #541