### PR TITLE
Add external dependencies option

### DIFF
--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -32,7 +32,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install tools dependencies
+      - name: Configure python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install conan and ninja
         run: pip install conan ninja
       - name: Install libraries dependencies
         run: |

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -28,15 +28,12 @@ jobs:
         run: docker run test
 
   external_dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install tools dependencies
-        run: |
-          sudo apt -qq update && \
-          sudo apt -qq install -y g++-13 ninja-build \
-          pip install conan
+        run: pip install conan ninja
       - name: Install libraries dependencies
         run: |
           CC=gcc-13 CXX=g++-13 conan profile detect && \

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -41,14 +41,18 @@ jobs:
       - name: Install libraries dependencies
         run: |
           CC=gcc-13 CXX=g++-13 conan profile detect && \
-          conan install -r conancenter --requires=fmt/10.2.1 --requires=gtest/1.14.0 -g CMakeToolchain -g CMakeDeps --build=missing -of conan
+          conan install -r conancenter -s compiler.cppstd=20 \
+            --requires=fmt/10.2.1 --requires=gtest/1.14.0 \
+            -g CMakeToolchain -g CMakeDeps \
+            --build=missing -of conan \
+            -c tools.build:compiler_executables='{"c": "gcc-13", "cxx": "g++-13"}'
       - name: CMake build
         run: |
           cmake -B build -S . -G Ninja \
             -DUSE_SYSTEM_DEPENDENCIES=ON \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_COMPILER=g++-13
+            -DCMAKE_CXX_COMPILER=g++-13 \
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake && \
           cmake --build build

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -25,3 +25,28 @@ jobs:
 
       - name: Run docker container
         run: docker run test
+
+  external_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install tools dependencies
+        run: |
+          sudo apt -qq update && \
+          sudo apt -qq install -y g++-13 ninja-build \
+          pip install conan
+      - name: Install libraries dependencies
+        run: |
+          CC=gcc-13 CXX=g++-13 conan profile detect && \
+          conan install -r conancenter --requires=fmt/10.2.1 --requires=gtest/1.14.0 -g CMakeToolchain -g CMakeDeps --build=missing -of conan
+      - name: CMake build
+        run: |
+          cmake -B build -S . -G Ninja \
+            -DUSE_SYSTEM_DEPENDENCIES=ON \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=g++-13
+            -DCMAKE_C_COMPILER=gcc-13 \
+            -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake && \
+          cmake --build build

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'feature/external-deps'
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -55,4 +55,4 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++-13 \
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake && \
-          cmake --build build --parallel 1
+          cmake --build build

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'feature/external-deps'
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -55,4 +55,4 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++-13 \
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake && \
-          cmake --build build
+          cmake --build build --parallel 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ option(USE_SYSTEM_DEPENDENCIES "Use fmt and GTest from system" OFF)
 if (NOT USE_SYSTEM_DEPENDENCIES)
     set(CMAKE_REQUIRED_FLAGS -std=c++20)
     include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles("#include <format>\nint main(){ return 0; }"
+    check_cxx_source_compiles("#include <format>\nint main(){ auto var = std::format(\"{}\", \"Hello\"); return 0; }"
         HAS_STD_FORMAT)
 endif()
 
@@ -153,6 +153,10 @@ if (BUILD_FAKER_TESTS)
     add_code_coverage_all_targets()
 
     add_executable(${LIBRARY_NAME}-UT ${FAKER_UT_SOURCES})
+    if (MSVC)
+        target_compile_options(${LIBRARY_NAME}-UT PRIVATE /permissive- /bigobj)
+    endif()
+
     if (USE_SYSTEM_DEPENDENCIES)
         find_package(GTest REQUIRED)
         target_link_libraries(${LIBRARY_NAME}-UT PRIVATE GTest::gtest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(CheckCXXSourceCompiles)
 set(CMAKE_REQUIRED_FLAGS -std=c++20)
-check_cxx_source_compiles("#include <format>\nint main(){ auto var = std::format(\"{}\", \"Hello\"); return 0; }" HAS_STD_FORMAT)
+check_cxx_source_compiles(
+    "#include <format>\nint main(){ auto var = std::format(\"{}\", \"Hello\"); return 0; }"
+    HAS_STD_FORMAT)
 
 option(BUILD_FAKER_TESTS DEFAULT ON)
-option(USE_SYSTEM_DEPENDENCIES "Use fmt and GTest from system" DEFAULT OFF)
+option(USE_SYSTEM_DEPENDENCIES "Use fmt and GTest from system" OFF)
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /bigobj")
@@ -155,9 +157,8 @@ if (BUILD_FAKER_TESTS)
     add_executable(${LIBRARY_NAME}-UT ${FAKER_UT_SOURCES})
     if (USE_SYSTEM_DEPENDENCIES)
         find_package(GTest REQUIRED)
-        find_package(GMock REQUIRED)
-        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE GTest::GTest
-            GTest::Main GMock::GMock GMock::Main faker-cxx)
+        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE GTest::gtest
+            GTest::gtest_main GTest::gmock GTest::gmock_main faker-cxx)
     else ()
         add_subdirectory(externals/googletest)
 
@@ -177,7 +178,8 @@ if (BUILD_FAKER_TESTS)
             ${CMAKE_CURRENT_LIST_DIR})
         target_compile_definitions(${LIBRARY_NAME}-UT PRIVATE HAS_STD_FORMAT)
     else ()
-        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE $<TARGET_EXISTS:fmt::fmt>:$<TARGET_NAME:fmt::fmt>,fmt)
+        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE
+            $<IF:$<TARGET_EXISTS:fmt::fmt>,fmt::fmt,fmt>)
         target_include_directories(
             ${LIBRARY_NAME}-UT
             PRIVATE ${FMT_INCLUDE_DIR} ${GTEST_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_20)
 if (MSVC)
     target_compile_options(${LIBRARY_NAME} PRIVATE /permissive- /bigobj)
 else ()
-    target_compile_options(${LIBRARY_NAME} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wformat -Werror)
+    target_compile_options(${LIBRARY_NAME} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wformat)
 endif ()
 
 install(TARGETS ${LIBRARY_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,15 @@ project(${PROJECT_NAME} CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(CheckCXXSourceCompiles)
-set(CMAKE_REQUIRED_FLAGS -std=c++20)
-check_cxx_source_compiles(
-    "#include <format>\nint main(){ auto var = std::format(\"{}\", \"Hello\"); return 0; }"
-    HAS_STD_FORMAT)
-
 option(BUILD_FAKER_TESTS DEFAULT ON)
 option(USE_SYSTEM_DEPENDENCIES "Use fmt and GTest from system" OFF)
+
+if (NOT USE_SYSTEM_DEPENDENCIES)
+    set(CMAKE_REQUIRED_FLAGS -std=c++20)
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("#include <format>\nint main(){ return 0; }"
+        HAS_STD_FORMAT)
+endif()
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /bigobj")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /bigobj")
 else ()
     set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wconversion -Wformat -Werror"
+        "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wconversion -Wformat"
     )
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /bigobj")
 else ()
     set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wconversion -Wformat"
+        "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wconversion -Wformat -Werror"
     )
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_REQUIRED_FLAGS -std=c++20)
 check_cxx_source_compiles("#include <format>\nint main(){ auto var = std::format(\"{}\", \"Hello\"); return 0; }" HAS_STD_FORMAT)
 
 option(BUILD_FAKER_TESTS DEFAULT ON)
+option(USE_SYSTEM_DEPENDENCIES "Use fmt and GTest from system" DEFAULT OFF)
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /bigobj")
@@ -131,8 +132,11 @@ install(EXPORT ${LIBRARY_NAME}-targets
     FILE ${LIBRARY_NAME}-config.cmake
     DESTINATION lib/cmake/${LIBRARY_NAME})
 
-if (HAS_STD_FORMAT)
+if (HAS_STD_FORMAT AND NOT USE_SYSTEM_DEPENDENCIES)
     target_compile_definitions(${LIBRARY_NAME} PRIVATE HAS_STD_FORMAT)
+elseif(USE_SYSTEM_DEPENDENCIES)
+    find_package(fmt REQUIRED)
+    target_link_libraries(${LIBRARY_NAME} PRIVATE fmt::fmt)
 else ()
     add_subdirectory(externals/fmt)
     set(FMT_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/externals/fmt/include")
@@ -140,13 +144,6 @@ else ()
 endif ()
 
 if (BUILD_FAKER_TESTS)
-    add_subdirectory(externals/googletest)
-
-    set(GTEST_INCLUDE_DIR
-        "${CMAKE_SOURCE_DIR}/externals/googletest/googletest/include")
-    set(GMOCK_INCLUDE_DIR
-        "${CMAKE_SOURCE_DIR}/externals/googletest/googlemock/include")
-
     enable_testing()
 
     set(target_code_coverage_ALL 1)
@@ -156,9 +153,22 @@ if (BUILD_FAKER_TESTS)
     add_code_coverage_all_targets()
 
     add_executable(${LIBRARY_NAME}-UT ${FAKER_UT_SOURCES})
+    if (USE_SYSTEM_DEPENDENCIES)
+        find_package(GTest REQUIRED)
+        find_package(GMock REQUIRED)
+        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE GTest::GTest
+            GTest::Main GMock::GMock GMock::Main faker-cxx)
+    else ()
+        add_subdirectory(externals/googletest)
 
-    target_link_libraries(${LIBRARY_NAME}-UT PRIVATE gtest_main gmock_main
-        faker-cxx)
+        set(GTEST_INCLUDE_DIR
+            "${CMAKE_SOURCE_DIR}/externals/googletest/googletest/include")
+        set(GMOCK_INCLUDE_DIR
+            "${CMAKE_SOURCE_DIR}/externals/googletest/googlemock/include")
+
+        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE gtest_main gmock_main
+            faker-cxx)
+    endif ()
 
     if (HAS_STD_FORMAT)
         target_include_directories(
@@ -167,7 +177,7 @@ if (BUILD_FAKER_TESTS)
             ${CMAKE_CURRENT_LIST_DIR})
         target_compile_definitions(${LIBRARY_NAME}-UT PRIVATE HAS_STD_FORMAT)
     else ()
-        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE fmt)
+        target_link_libraries(${LIBRARY_NAME}-UT PRIVATE $<TARGET_EXISTS:fmt::fmt>:$<TARGET_NAME:fmt::fmt>,fmt)
         target_include_directories(
             ${LIBRARY_NAME}-UT
             PRIVATE ${FMT_INCLUDE_DIR} ${GTEST_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,6 @@ if (NOT USE_SYSTEM_DEPENDENCIES)
         HAS_STD_FORMAT)
 endif()
 
-if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /bigobj")
-else ()
-    set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wconversion -Wformat -Werror"
-    )
-endif ()
-
 set(LIBRARY_NAME faker-cxx)
 
 set(FAKER_SOURCES
@@ -117,6 +109,11 @@ target_include_directories(
     $<INSTALL_INTERFACE:include>)
 
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_20)
+if (MSVC)
+    target_compile_options(${LIBRARY_NAME} PRIVATE /permissive- /bigobj)
+else ()
+    target_compile_options(${LIBRARY_NAME} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wformat -Werror)
+endif ()
 
 install(TARGETS ${LIBRARY_NAME}
     EXPORT ${LIBRARY_NAME}-targets

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ int main()
 
     ```cmake
     set(BUILD_FAKER_TESTS OFF)
-    
+
     add_subdirectory(externals/faker-cxx)
-    
+
     add_executable(main Main.cpp)
-    
+
     target_link_libraries(main faker-cxx)
     ```
 
@@ -126,10 +126,12 @@ If you have any confusion please refer to the respective guides.
 - GTest (set `BUILD_FAKER_CXX_TESTS=OFF` CMake flag to disable this dependency)
 - fmt (only for compilers that don't support std::format)
 
+In order to use external dependencies installed in your system, you can set the `USE_SYSTEM_DEPENDENCIES` CMake flag to `ON`.
+
 ## ✨ Contributing
 
 We would love it if you contributed to Faker C++! 🚀
 
-Before contributing please review our [CONTRIBUTING](https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md) guide. 
+Before contributing please review our [CONTRIBUTING](https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md) guide.
 
 Additionally, we encourage you to join our [Discord Channel](https://discord.gg/h2ur8H6mK6) for contributors.


### PR DESCRIPTION
Add support to use external dependencies instead of vendorized ones. The new CMake option `USE_SYSTEM_DEPENDENCIES`, uses `find_package` to include (mandatory) fmt and gtest. In case that option is enabled, and the compiler has std::format supported, CMake will use the external dependencies, because the user configured it explicitly.

Added a new CI job to validate the configuration.

closes #546