### PR TITLE
Fix clang build

### DIFF
--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           cmake -S ${{github.workspace}} -B ${{github.workspace}}/build \
             -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+            -DCMAKE_C_COMPILER=/usr/bin/clang-18 \
             -DCMAKE_CXX_COMPILER=/usr/bin/clang++-18 \
             -DCODE_COVERAGE:BOOL=ON \
             -GNinja

--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Install apt-get dependencies
         run: |
-          sudo -qq apt update \
-           && sudo apt-get install -y ninja-build llvm-cov-16
+          sudo apt -qq update \
+           && sudo apt install -y --no-install-recommends --no-install-suggests ninja-build llvm-cov-16
 
       - name: Initialize submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -23,16 +23,16 @@ jobs:
       - name: Install apt-get dependencies
         run: |
           sudo apt -qq update \
-           && sudo apt install -y --no-install-recommends --no-install-suggests ninja-build llvm-cov-16
+           && sudo apt install -y --no-install-recommends --no-install-suggests ninja-build
 
       - name: Initialize submodules
         run: git submodule update --init --recursive
 
       - name: Configure CMake
         run: |
-          cmake -B ${{github.workspace}}/build \
+          cmake -S ${{github.workspace}} -B ${{github.workspace}}/build \
             -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/clang++-16 \
+            -DCMAKE_CXX_COMPILER=/usr/bin/clang++-18 \
             -DCODE_COVERAGE:BOOL=ON \
             -GNinja
 
@@ -43,7 +43,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: |
           ninja faker-ccov-all \
-          && llvm-cov-16 show `cat ccov/binaries.list` -instr-profile=ccov/all-merged.profdata > coverage.txt
+          && llvm-cov-18 show `cat ccov/binaries.list` -instr-profile=ccov/all-merged.profdata > coverage.txt
 
       - name: Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -22,15 +22,8 @@ jobs:
 
       - name: Install apt-get dependencies
         run: |
-          sudo add-apt-repository ppa:trebelnik-stefina/launchpad-getkeys \
-           && sudo apt-get update \
-           && sudo apt-get install launchpad-getkeys \
-           && sudo sudo apt-get update \
-           && sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' \
-           && sudo launchpad-getkeys \
-           && sudo apt-get update -y \
-           && sudo apt-get install -y lld-16 ninja-build build-essential libstdc++-13-dev \
-             clang-16 clang-tools-16 llvm-16 lcov
+          sudo -qq apt update \
+           && sudo apt-get install -y ninja-build llvm-cov-16
 
       - name: Initialize submodules
         run: git submodule update --init --recursive

--- a/cmake/cmake-coverage.cmake
+++ b/cmake/cmake-coverage.cmake
@@ -80,8 +80,8 @@ option(
     OFF)
 
 # Programs
-find_program(LLVM_COV_PATH llvm-cov-16)
-find_program(LLVM_PROFDATA_PATH llvm-profdata-16)
+find_program(LLVM_COV_PATH llvm-cov-18)
+find_program(LLVM_PROFDATA_PATH llvm-profdata-18)
 find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
 # Hide behind the 'advanced' mode flag for GUI/ccmake


### PR DESCRIPTION
This PR fixes the current build on Linux using Clang.

Plus, it update Clang version 18, available in Ubuntu 24.04.

The Runner provided by Github action has LLVM 18 installed already, so don't need to bother installing basic stuff, like CMake. Only Ninja is really not installed by default. 