### PR TITLE
[hotfix] Run single core when building with GCC

### DIFF
--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -33,7 +33,7 @@ jobs:
             -DBUILD_TESTING:BOOL=ON
 
       - name: Build
-        run: cmake --build --preset=unixlike-gcc-debug
+        run: cmake --build --preset=unixlike-gcc-debug --parallel 1
 
       - name: Test
         run: ctest --preset=unixlike-gcc-debug


### PR DESCRIPTION
Let's see if we can avoid the current CI error with GCC 12 by running a single core to use less memory.

