### PR TITLE
Apply clang-tidy fix for misc-clean-include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ cmake_minimum_required(VERSION 3.22)
 set(PROJECT_NAME faker-cxx)
 project(${PROJECT_NAME} CXX)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 option(USE_SYSTEM_DEPENDENCIES "Use fmt and GTest from system" OFF)
 
 if (NOT USE_SYSTEM_DEPENDENCIES)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -102,7 +102,8 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             }
         },
         {
@@ -113,7 +114,8 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             }
         }
     ],

--- a/src/common/FormatHelper.cpp
+++ b/src/common/FormatHelper.cpp
@@ -1,6 +1,9 @@
 #include "FormatHelper.h"
 
+#include <functional>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
 
 namespace faker
 {

--- a/src/common/LuhnCheck.cpp
+++ b/src/common/LuhnCheck.cpp
@@ -1,5 +1,9 @@
 #include "LuhnCheck.h"
 
+#include <algorithm>
+#include <cctype>
+#include <string>
+
 namespace faker
 {
 int LuhnCheck::luhnCheckSum(const std::string& inputString)

--- a/src/common/PrecisionMapper.cpp
+++ b/src/common/PrecisionMapper.cpp
@@ -1,5 +1,9 @@
 #include "PrecisionMapper.h"
 
+#include <unordered_map>
+
+#include "faker-cxx/types/Precision.h"
+
 namespace faker
 {
 const std::unordered_map<Precision, unsigned> PrecisionMapper::precisionToDecimalPlacesMapping{

--- a/src/common/StringHelper.cpp
+++ b/src/common/StringHelper.cpp
@@ -2,7 +2,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <sstream>
+#include <string>
+#include <vector>
 
 namespace faker
 {

--- a/src/modules/airline/Airline.cpp
+++ b/src/modules/airline/Airline.cpp
@@ -1,5 +1,8 @@
 #include "faker-cxx/Airline.h"
 
+#include <string>
+#include <string_view>
+
 #include "AirlineData.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/Number.h"

--- a/src/modules/airline/AirlineData.cpp
+++ b/src/modules/airline/AirlineData.cpp
@@ -1,5 +1,11 @@
 #include "AirlineData.h"
 
+#include <array>
+#include <string_view>
+#include <unordered_map>
+
+#include "faker-cxx/Airline.h"
+
 namespace faker
 {
 const std::array<std::string_view, 3> aircraftTypes = {"regional", "narrowbody", "widebody"};

--- a/src/modules/animal/Animal.cpp
+++ b/src/modules/animal/Animal.cpp
@@ -1,5 +1,7 @@
 #include "faker-cxx/Animal.h"
 
+#include <string_view>
+
 #include "AnimalData.h"
 #include "faker-cxx/Helper.h"
 

--- a/src/modules/animal/AnimalData.cpp
+++ b/src/modules/animal/AnimalData.cpp
@@ -1,5 +1,8 @@
 #include "AnimalData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 8> bears = {"Giant panda",         "Spectacled bear",  "Sun bear",   "Sloth bear",

--- a/src/modules/book/Book.cpp
+++ b/src/modules/book/Book.cpp
@@ -1,9 +1,11 @@
 #include "faker-cxx/Book.h"
 
+#include <string>
+#include <string_view>
+
 #include "../../common/FormatHelper.h"
 #include "BookData.h"
 #include "faker-cxx/Helper.h"
-#include "faker-cxx/Number.h"
 #include "faker-cxx/String.h"
 
 namespace faker

--- a/src/modules/book/BookData.cpp
+++ b/src/modules/book/BookData.cpp
@@ -1,5 +1,8 @@
 #include "BookData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 100> authors = {"Shakespeare, William",

--- a/src/modules/color/Color.cpp
+++ b/src/modules/color/Color.cpp
@@ -1,10 +1,14 @@
 #include "faker-cxx/Color.h"
 
+#include <string>
+#include <string_view>
+
 #include "../../common/FormatHelper.h"
 #include "ColorData.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/Number.h"
 #include "faker-cxx/String.h"
+#include "faker-cxx/types/Hex.h"
 
 namespace faker
 {

--- a/src/modules/color/ColorData.cpp
+++ b/src/modules/color/ColorData.cpp
@@ -1,5 +1,8 @@
 #include "ColorData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 31> colors = {

--- a/src/modules/commerce/Commerce.cpp
+++ b/src/modules/commerce/Commerce.cpp
@@ -1,9 +1,15 @@
 #include "faker-cxx/Commerce.h"
 
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <string_view>
+
 #include "../../common/FormatHelper.h"
 #include "CommerceData.h"
 #include "faker-cxx/Finance.h"
 #include "faker-cxx/Helper.h"
+#include "faker-cxx/Number.h"
 #include "faker-cxx/String.h"
 
 namespace faker

--- a/src/modules/commerce/CommerceData.cpp
+++ b/src/modules/commerce/CommerceData.cpp
@@ -1,5 +1,8 @@
 #include "CommerceData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 22> departments = {

--- a/src/modules/company/Company.cpp
+++ b/src/modules/company/Company.cpp
@@ -1,8 +1,12 @@
 #include "faker-cxx/Company.h"
 
+#include <string>
+#include <string_view>
+
 #include "../../common/FormatHelper.h"
 #include "CompanyData.h"
 #include "faker-cxx/Helper.h"
+#include "faker-cxx/Number.h"
 #include "faker-cxx/Person.h"
 
 namespace faker

--- a/src/modules/company/CompanyData.cpp
+++ b/src/modules/company/CompanyData.cpp
@@ -1,5 +1,8 @@
 #include "CompanyData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 65> buzzAdjectives = {"clicks-and-mortar",

--- a/src/modules/computer/Computer.cpp
+++ b/src/modules/computer/Computer.cpp
@@ -1,5 +1,7 @@
 #include "faker-cxx/Computer.h"
 
+#include <string_view>
+
 #include "ComputerData.h"
 #include "faker-cxx/Helper.h"
 

--- a/src/modules/computer/ComputerData.cpp
+++ b/src/modules/computer/ComputerData.cpp
@@ -1,5 +1,8 @@
 #include "ComputerData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 4> computerTypes = {"Desktop", "Laptop", "Mainframe", "Supercomputer"};

--- a/src/modules/crypto/Crypto.cpp
+++ b/src/modules/crypto/Crypto.cpp
@@ -4,7 +4,10 @@
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
+#include <ios>
+#include <optional>
 #include <sstream>
+#include <string>
 
 #include "faker-cxx/Word.h"
 

--- a/src/modules/database/Database.cpp
+++ b/src/modules/database/Database.cpp
@@ -1,8 +1,12 @@
 #include "faker-cxx/Database.h"
 
+#include <string>
+#include <string_view>
+
 #include "DatabaseData.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/String.h"
+#include "faker-cxx/types/Hex.h"
 
 namespace faker
 {

--- a/src/modules/database/DatabaseData.cpp
+++ b/src/modules/database/DatabaseData.cpp
@@ -1,5 +1,8 @@
 #include "DatabaseData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 7> collations = {"utf8_unicode_ci",  "utf8_general_ci",  "utf8_bin",

--- a/src/modules/datatype/Datatype.cpp
+++ b/src/modules/datatype/Datatype.cpp
@@ -1,5 +1,7 @@
 #include "faker-cxx/Datatype.h"
 
+#include <cmath>
+
 #include "faker-cxx/Number.h"
 
 namespace faker

--- a/src/modules/date/Date.cpp
+++ b/src/modules/date/Date.cpp
@@ -4,6 +4,9 @@
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
 #include "../../common/FormatHelper.h"
 #include "DateData.h"

--- a/src/modules/date/DateData.cpp
+++ b/src/modules/date/DateData.cpp
@@ -1,5 +1,8 @@
 #include "DateData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 12> monthNames = {

--- a/src/modules/finance/Finance.cpp
+++ b/src/modules/finance/Finance.cpp
@@ -1,11 +1,21 @@
 #include "faker-cxx/Finance.h"
 
+#include <cstddef>
+#include <ios>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "../../common/FormatHelper.h"
 #include "../../common/PrecisionMapper.h"
 #include "faker-cxx/Date.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/Number.h"
 #include "faker-cxx/String.h"
+#include "faker-cxx/types/Hex.h"
+#include "faker-cxx/types/Precision.h"
 #include "FinanceData.h"
 
 namespace faker

--- a/src/modules/finance/FinanceData.cpp
+++ b/src/modules/finance/FinanceData.cpp
@@ -1,5 +1,12 @@
 #include "FinanceData.h"
 
+#include <array>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "faker-cxx/Finance.h"
+
 namespace faker
 {
 const std::array<Finance::BicCountry, 10> bicCountries{

--- a/src/modules/food/Food.cpp
+++ b/src/modules/food/Food.cpp
@@ -1,5 +1,7 @@
 #include "faker-cxx/Food.h"
 
+#include <string_view>
+
 #include "faker-cxx/Helper.h"
 #include "FoodData.h"
 

--- a/src/modules/food/FoodData.cpp
+++ b/src/modules/food/FoodData.cpp
@@ -1,5 +1,8 @@
 #include "FoodData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 47> alcoholicBeverages{

--- a/src/modules/git/Git.cpp
+++ b/src/modules/git/Git.cpp
@@ -1,5 +1,9 @@
 #include "faker-cxx/Git.h"
 
+#include <cstddef>
+#include <optional>
+#include <string>
+
 #include "../../common/FormatHelper.h"
 #include "../../common/StringHelper.h"
 #include "../date/DateData.h"
@@ -8,6 +12,8 @@
 #include "faker-cxx/Number.h"
 #include "faker-cxx/Person.h"
 #include "faker-cxx/String.h"
+#include "faker-cxx/types/Country.h"
+#include "faker-cxx/types/Hex.h"
 #include "faker-cxx/Word.h"
 
 namespace faker

--- a/src/modules/hacker/Hacker.cpp
+++ b/src/modules/hacker/Hacker.cpp
@@ -1,5 +1,8 @@
 #include "faker-cxx/Hacker.h"
 
+#include <string>
+#include <string_view>
+
 #include "../../common/StringHelper.h"
 #include "faker-cxx/Helper.h"
 #include "HackerData.h"

--- a/src/modules/hacker/HackerData.cpp
+++ b/src/modules/hacker/HackerData.cpp
@@ -1,5 +1,8 @@
 #include "HackerData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 16> abbreviations = {

--- a/src/modules/helper/Helper.cpp
+++ b/src/modules/helper/Helper.cpp
@@ -1,12 +1,14 @@
 #include "faker-cxx/Helper.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <random>
 #include <regex>
 #include <string>
 
 #include "../../common/LuhnCheck.h"
 #include "../../common/StringHelper.h"
+#include "faker-cxx/Number.h"
 
 namespace faker
 {

--- a/src/modules/image/Image.cpp
+++ b/src/modules/image/Image.cpp
@@ -1,6 +1,9 @@
 #include "faker-cxx/Image.h"
 
 #include <array>
+#include <optional>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "../../common/FormatHelper.h"

--- a/src/modules/internet/Internet.cpp
+++ b/src/modules/internet/Internet.cpp
@@ -1,20 +1,28 @@
 #include "faker-cxx/Internet.h"
 
+#include <algorithm>
 #include <array>
-#include <vector>
+#include <cstddef>
 #include <initializer_list>
-#include <unordered_map>
 #include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #include "common/FormatHelper.h"
 #include "common/StringHelper.h"
-#include "modules/string/StringData.h"
-#include "InternetData.h"
 #include "faker-cxx/Helper.h"
+#include "faker-cxx/Number.h"
 #include "faker-cxx/Person.h"
 #include "faker-cxx/String.h"
 #include "faker-cxx/types/Country.h"
+#include "faker-cxx/types/Hex.h"
 #include "faker-cxx/Word.h"
+#include "InternetData.h"
+#include "modules/string/StringData.h"
 
 namespace faker
 {

--- a/src/modules/internet/InternetData.cpp
+++ b/src/modules/internet/InternetData.cpp
@@ -1,5 +1,8 @@
 #include "InternetData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker::internet
 {
 const std::array<std::string_view, 6> domainSuffixes = {

--- a/src/modules/location/Location.cpp
+++ b/src/modules/location/Location.cpp
@@ -1,12 +1,19 @@
 #include "faker-cxx/Location.h"
 
+#include <functional>
+#include <ios>
 #include <sstream>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "../../common/FormatHelper.h"
 #include "../../common/PrecisionMapper.h"
 #include "faker-cxx/Helper.h"
+#include "faker-cxx/Number.h"
 #include "faker-cxx/Person.h"
+#include "faker-cxx/types/Country.h"
+#include "faker-cxx/types/Precision.h"
 #include "LocationData.h"
 
 namespace faker

--- a/src/modules/location/LocationData.cpp
+++ b/src/modules/location/LocationData.cpp
@@ -1,5 +1,8 @@
 #include "LocationData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 246> allCountries = {

--- a/src/modules/lorem/Lorem.cpp
+++ b/src/modules/lorem/Lorem.cpp
@@ -1,9 +1,15 @@
 #include "faker-cxx/Lorem.h"
 
+#include <cctype>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "../../common/FormatHelper.h"
 #include "../../common/StringHelper.h"
-#include "LoremData.h"
 #include "faker-cxx/Helper.h"
+#include "faker-cxx/Number.h"
+#include "LoremData.h"
 
 namespace faker
 {

--- a/src/modules/lorem/LoremData.cpp
+++ b/src/modules/lorem/LoremData.cpp
@@ -1,5 +1,8 @@
 #include "LoremData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 

--- a/src/modules/medicine/Medicine.cpp
+++ b/src/modules/medicine/Medicine.cpp
@@ -1,7 +1,9 @@
 #include "faker-cxx/Medicine.h"
 
-#include "MedicineData.h"
+#include <string_view>
+
 #include "faker-cxx/Helper.h"
+#include "MedicineData.h"
 
 namespace faker
 {

--- a/src/modules/medicine/MedicineData.cpp
+++ b/src/modules/medicine/MedicineData.cpp
@@ -1,5 +1,8 @@
 #include "MedicineData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker::medicine {
 const std::array<std::string_view, 59> medicalConditions = {
     "AIDS",

--- a/src/modules/movie/Movie.cpp
+++ b/src/modules/movie/Movie.cpp
@@ -1,7 +1,9 @@
 #include "faker-cxx/Movie.h"
 
-#include "MovieData.h"
+#include <string_view>
+
 #include "faker-cxx/Helper.h"
+#include "MovieData.h"
 
 namespace faker
 {

--- a/src/modules/movie/MovieData.cpp
+++ b/src/modules/movie/MovieData.cpp
@@ -1,5 +1,8 @@
 #include "MovieData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 const std::array<std::string_view, 299> actors = {

--- a/src/modules/music/Music.cpp
+++ b/src/modules/music/Music.cpp
@@ -1,7 +1,9 @@
 #include "faker-cxx/Music.h"
 
-#include "MusicData.h"
+#include <string_view>
+
 #include "faker-cxx/Helper.h"
+#include "MusicData.h"
 
 namespace faker
 {

--- a/src/modules/music/MusicData.cpp
+++ b/src/modules/music/MusicData.cpp
@@ -1,5 +1,8 @@
 #include "MusicData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker::music
 {
 const std::array<std::string_view, 298> artists = {

--- a/src/modules/number/Number.cpp
+++ b/src/modules/number/Number.cpp
@@ -1,5 +1,7 @@
 #include "faker-cxx/Number.h"
 
+#include <random>
+
 namespace faker
 {
 std::random_device Number::randomDevice;

--- a/src/modules/person/Person.cpp
+++ b/src/modules/person/Person.cpp
@@ -1,10 +1,11 @@
 #include "faker-cxx/Person.h"
 
-#include <regex>
+#include <functional>
+#include <optional>
 #include <set>
-#include <unordered_map>
 #include <string>
-#include <string_view>
+#include <unordered_map>
+#include <vector>
 
 #include "common/FormatHelper.h"
 #include "data/albania/AlbanianPeopleNames.h"
@@ -79,8 +80,11 @@
 #include "data/ZodiacSigns.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/Internet.h"
+#include "faker-cxx/Number.h"
 #include "faker-cxx/String.h"
+#include "faker-cxx/types/Country.h"
 #include "faker-cxx/Word.h"
+#include "modules/person/data/PeopleNames.h"
 
 namespace faker
 {

--- a/src/modules/phone/Phone.cpp
+++ b/src/modules/phone/Phone.cpp
@@ -1,7 +1,12 @@
 #include "faker-cxx/Phone.h"
 
-#include "PhoneData.h"
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
 #include "faker-cxx/Helper.h"
+#include "PhoneData.h"
 
 namespace faker
 {

--- a/src/modules/phone/PhoneData.cpp
+++ b/src/modules/phone/PhoneData.cpp
@@ -1,5 +1,8 @@
 #include "PhoneData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker::phone
 {
 const std::array<std::string_view, 217> areaCodes = {

--- a/src/modules/sport/SportData.cpp
+++ b/src/modules/sport/SportData.cpp
@@ -1,5 +1,8 @@
 #include "SportData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker::sport
 {
 const std::array<std::string_view, 10> femaleAthletes = {

--- a/src/modules/string/String.cpp
+++ b/src/modules/string/String.cpp
@@ -1,15 +1,19 @@
 #include "faker-cxx/String.h"
 
+#include <algorithm>
 #include <cassert>
+#include <ios>
+#include <map>
+#include <optional>
+#include <set>
+#include <sstream>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
-#include <map>
-#include <algorithm>
 
-#include "StringData.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/Number.h"
+#include "faker-cxx/types/Hex.h"
+#include "StringData.h"
 
 namespace faker
 {

--- a/src/modules/system/System.cpp
+++ b/src/modules/system/System.cpp
@@ -1,8 +1,12 @@
 #include "faker-cxx/System.h"
 
-#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <optional>
 #include <set>
+#include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "../src/common/StringHelper.h"
@@ -10,8 +14,10 @@
 #include "data/CronDayOfWeek.h"
 #include "data/DirectoryPath.h"
 #include "data/MimeTypes.h"
+#include "faker-cxx/Datatype.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/Internet.h"
+#include "faker-cxx/Number.h"
 #include "faker-cxx/String.h"
 #include "faker-cxx/Word.h"
 

--- a/src/modules/vehicle/Vehicle.cpp
+++ b/src/modules/vehicle/Vehicle.cpp
@@ -1,10 +1,13 @@
 #include "faker-cxx/Vehicle.h"
 
+#include <string>
+#include <string_view>
+
 #include "common/FormatHelper.h"
-#include "VehicleData.h"
 #include "faker-cxx/Helper.h"
 #include "faker-cxx/Number.h"
 #include "faker-cxx/String.h"
+#include "VehicleData.h"
 
 namespace faker
 {

--- a/src/modules/vehicle/VehicleData.cpp
+++ b/src/modules/vehicle/VehicleData.cpp
@@ -1,5 +1,8 @@
 #include "VehicleData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 namespace vehicle

--- a/src/modules/videoGame/VideoGame.cpp
+++ b/src/modules/videoGame/VideoGame.cpp
@@ -1,7 +1,9 @@
 #include "faker-cxx/VideoGame.h"
 
-#include "VideoGameData.h"
+#include <string_view>
+
 #include "faker-cxx/Helper.h"
+#include "VideoGameData.h"
 
 
 namespace faker

--- a/src/modules/videoGame/VideoGameData.cpp
+++ b/src/modules/videoGame/VideoGameData.cpp
@@ -1,5 +1,8 @@
 #include "VideoGameData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 namespace videoGame

--- a/src/modules/weather/WeatherData.cpp
+++ b/src/modules/weather/WeatherData.cpp
@@ -1,5 +1,8 @@
 #include "WeatherData.h"
 
+#include <array>
+#include <string_view>
+
 namespace faker
 {
 

--- a/src/modules/word/Word.cpp
+++ b/src/modules/word/Word.cpp
@@ -1,5 +1,9 @@
 #include "faker-cxx/Word.h"
 
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "../../common/StringHelper.h"
 #include "data/Adjectives.h"
 #include "data/Adverbs.h"

--- a/tests/common/FormatHelperTest.cpp
+++ b/tests/common/FormatHelperTest.cpp
@@ -1,5 +1,10 @@
 #include "FormatHelper.h"
 
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
 #include "gtest/gtest.h"
 
 using namespace ::testing;

--- a/tests/common/LuhnCheckTest.cpp
+++ b/tests/common/LuhnCheckTest.cpp
@@ -1,6 +1,5 @@
 #include "LuhnCheck.h"
 
-#include <algorithm>
 #include <gtest/gtest.h>
 #include <string>
 

--- a/tests/common/PrecisionMapperTest.cpp
+++ b/tests/common/PrecisionMapperTest.cpp
@@ -2,6 +2,8 @@
 
 #include "gtest/gtest.h"
 
+#include "faker-cxx/types/Precision.h"
+
 using namespace ::testing;
 using namespace faker;
 

--- a/tests/common/StringHelperTest.cpp
+++ b/tests/common/StringHelperTest.cpp
@@ -1,6 +1,6 @@
 ﻿#include "StringHelper.h"
 
-#include <algorithm>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/airline/AirlineTest.cpp
+++ b/tests/modules/airline/AirlineTest.cpp
@@ -1,6 +1,9 @@
 #include "faker-cxx/Airline.h"
 
 #include <algorithm>
+#include <cctype>
+#include <string>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/animal/AnimalTest.cpp
+++ b/tests/modules/animal/AnimalTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Animal.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/book/BookTest.cpp
+++ b/tests/modules/book/BookTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Book.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/color/ColorTest.cpp
+++ b/tests/modules/color/ColorTest.cpp
@@ -2,11 +2,14 @@
 
 #include <algorithm>
 #include <charconv>
+#include <string>
+#include <string_view>
 
 #include "gtest/gtest.h"
 
 #include "color/ColorData.h"
 #include "common/StringHelper.h"
+#include "faker-cxx/types/Hex.h"
 #include "string/StringData.h"
 
 using namespace ::testing;

--- a/tests/modules/commerce/CommerceTest.cpp
+++ b/tests/modules/commerce/CommerceTest.cpp
@@ -1,6 +1,10 @@
 #include "faker-cxx/Commerce.h"
 
 #include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <string>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/company/CompanyTest.cpp
+++ b/tests/modules/company/CompanyTest.cpp
@@ -1,6 +1,8 @@
 #include "faker-cxx/Company.h"
 
 #include <algorithm>
+#include <string_view>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/computer/ComputerTest.cpp
+++ b/tests/modules/computer/ComputerTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Computer.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/crypto/CryptoTest.cpp
+++ b/tests/modules/crypto/CryptoTest.cpp
@@ -1,7 +1,7 @@
 #include "faker-cxx/Crypto.h"
 
-#include <algorithm>
 #include <regex>
+#include <string>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/database/DatabaseTest.cpp
+++ b/tests/modules/database/DatabaseTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Database.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/datatype/DatatypeTest.cpp
+++ b/tests/modules/datatype/DatatypeTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Datatype.h"
 
 #include <algorithm>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/date/DateTest.cpp
+++ b/tests/modules/date/DateTest.cpp
@@ -2,6 +2,15 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <ratio>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <time.h>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/finance/FinanceTest.cpp
+++ b/tests/modules/finance/FinanceTest.cpp
@@ -1,14 +1,17 @@
 #include "faker-cxx/Finance.h"
 
 #include <algorithm>
-#include <charconv>
 #include <ranges>
 #include <regex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 #include "gtest/gtest.h"
 
 #include "common/LuhnCheck.h"
 #include "common/StringHelper.h"
+#include "faker-cxx/types/Precision.h"
 #include "finance/FinanceData.h"
 #include "gmock/gmock.h"
 #include "string/StringData.h"

--- a/tests/modules/food/FoodTest.cpp
+++ b/tests/modules/food/FoodTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Food.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/git/GitTest.cpp
+++ b/tests/modules/git/GitTest.cpp
@@ -1,8 +1,8 @@
 #include "faker-cxx/Git.h"
 
-#include <algorithm>
 #include <regex>
 #include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/hacker/HackerTest.cpp
+++ b/tests/modules/hacker/HackerTest.cpp
@@ -1,6 +1,8 @@
 #include "faker-cxx/Hacker.h"
 
 #include <algorithm>
+#include <string>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/helper/HelperTest.cpp
+++ b/tests/modules/helper/HelperTest.cpp
@@ -1,8 +1,13 @@
 #include "faker-cxx/Helper.h"
 
 #include <algorithm>
+#include <cctype>
 #include <regex>
+#include <set>
+#include <span>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "gtest/gtest.h"

--- a/tests/modules/image/ImageTest.cpp
+++ b/tests/modules/image/ImageTest.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <string>
 #include <string_view>
 
 #include "gtest/gtest.h"

--- a/tests/modules/internet/InternetTest.cpp
+++ b/tests/modules/internet/InternetTest.cpp
@@ -1,13 +1,23 @@
 #include "faker-cxx/Internet.h"
 
 #include <algorithm>
-#include <string_view>
+#include <array>
+#include <cctype>
 #include <charconv>
+#include <cstddef>
 #include <initializer_list>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "gtest/gtest.h"
 
 #include "common/StringHelper.h"
+#include "faker-cxx/Number.h"
+#include "faker-cxx/types/Country.h"
+#include "internet/InternetData.h"
 #include "person/data/england/EnglishFirstNames.h"
 #include "person/data/england/EnglishLastNames.h"
 #include "person/data/romania/RomanianFirstNames.h"
@@ -15,8 +25,6 @@
 #include "string/StringData.h"
 #include "word/data/Adjectives.h"
 #include "word/data/Nouns.h"
-#include "internet/InternetData.h"
-#include "faker-cxx/Number.h"
 
 using namespace ::testing;
 using namespace faker;

--- a/tests/modules/location/LocationTest.cpp
+++ b/tests/modules/location/LocationTest.cpp
@@ -1,10 +1,16 @@
 #include "faker-cxx/Location.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
 
 #include "gtest/gtest.h"
 
 #include "common/StringHelper.h"
+#include "faker-cxx/types/Precision.h"
 #include "location/LocationData.h"
 #include "person/data/australia/AustralianFirstNames.h"
 #include "person/data/australia/AustralianLastNames.h"

--- a/tests/modules/lorem/LoremTest.cpp
+++ b/tests/modules/lorem/LoremTest.cpp
@@ -1,6 +1,8 @@
 #include "faker-cxx/Lorem.h"
 
 #include <algorithm>
+#include <cctype>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/movie/MovieTest.cpp
+++ b/tests/modules/movie/MovieTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Movie.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/number/NumberTest.cpp
+++ b/tests/modules/number/NumberTest.cpp
@@ -1,5 +1,7 @@
 #include "faker-cxx/Number.h"
 
+#include <stdexcept>
+
 #include "gtest/gtest.h"
 
 using namespace ::testing;

--- a/tests/modules/person/PersonTest.cpp
+++ b/tests/modules/person/PersonTest.cpp
@@ -1,11 +1,17 @@
 #include "faker-cxx/Person.h"
 
 #include <algorithm>
+#include <cctype>
 #include <regex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "gtest/gtest.h"
 
 #include "faker-cxx/Internet.h"
+#include "faker-cxx/types/Country.h"
 #include "person/data/albania/AlbanianPeopleNames.h"
 #include "person/data/argentina/ArgentinianPeopleNames.h"
 #include "person/data/australia/AustralianPeopleNames.h"
@@ -76,6 +82,7 @@
 #include "person/data/usa/UsaPeopleNames.h"
 #include "person/data/vietnam/VietnamesePeopleNames.h"
 #include "person/data/ZodiacSigns.h"
+#include "StringHelper.h"
 #include "word/data/Nouns.h"
 
 using namespace ::testing;

--- a/tests/modules/phone/PhoneTest.cpp
+++ b/tests/modules/phone/PhoneTest.cpp
@@ -1,7 +1,7 @@
 #include "faker-cxx/Phone.h"
 
 #include <algorithm>
-#include <vector>
+#include <cctype>
 #include <string>
 #include <string_view>
 

--- a/tests/modules/science/ScienceTest.cpp
+++ b/tests/modules/science/ScienceTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/Science.h"
 
 #include <algorithm>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/string/StringTest.cpp
+++ b/tests/modules/string/StringTest.cpp
@@ -1,13 +1,17 @@
 #include "faker-cxx/String.h"
 
 #include <algorithm>
+#include <cctype>
 #include <random>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 #include "gtest/gtest.h"
 
-#include "string/StringData.h"
 #include "faker-cxx/RandomGenerator.h"
+#include "faker-cxx/types/Hex.h"
+#include "string/StringData.h"
 
 using namespace ::testing;
 using namespace faker;

--- a/tests/modules/system/SystemTest.cpp
+++ b/tests/modules/system/SystemTest.cpp
@@ -1,7 +1,13 @@
 #include "faker-cxx/System.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <optional>
 #include <regex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/videoGame/VideoGameTest.cpp
+++ b/tests/modules/videoGame/VideoGameTest.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/VideoGame.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/word/WordTest.cpp
+++ b/tests/modules/word/WordTest.cpp
@@ -1,6 +1,8 @@
 #include "faker-cxx/Word.h"
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
I just started to run clang-tidy and resulted in tons of warnings, so I decided to split some fixes instead of pushing everything at once, so anyone can review much easier.

This time I executed in Linux:

```
cmake -S . --preset unixlike-clang-debug -DBUILD_TESTING:BOOL=ON -DCMAKE_CXX_CLANG_TIDY=clang-tidy-18
cmake --build --preset unixlike-clang-debug
run-clang-tidy-18 -p build/unixlike-gcc-debug/ -checks="misc-include-cleaner" -fix
```

The is including what we use for each file, which means, we use `std::array` but actually we import from a header that's using it. It's a fragile situation, any change could result in compilation error.