### PR TITLE
Add separated compiler warnings cmake file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ html/
 latex/
 
 CMakeSettings.json
+CMakeUserPresets.json
 .vs/
 out/
 build-linux-gxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
+project(faker-cxx LANGUAGES CXX)
 
-set(PROJECT_NAME faker-cxx)
-project(${PROJECT_NAME} CXX)
+include(cmake/CompilerWarnings.cmake)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -20,8 +20,6 @@ if (BUILD_TESTING)
     include("cmake/cmake-coverage.cmake")
     add_code_coverage_all_targets()
 endif ()
-
-set(LIBRARY_NAME faker-cxx)
 
 set(FAKER_SOURCES
     src/modules/airline/Airline.cpp
@@ -87,28 +85,28 @@ set(FAKER_SOURCES
     src/common/PrecisionMapper.cpp
 )
 
-add_library(${LIBRARY_NAME} ${FAKER_SOURCES})
+add_library(${CMAKE_PROJECT_NAME} ${FAKER_SOURCES})
 
 target_include_directories(
-    ${LIBRARY_NAME} PUBLIC
+    ${CMAKE_PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
 target_include_directories(
-    ${LIBRARY_NAME} PRIVATE
+    ${CMAKE_PROJECT_NAME} PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
 
-target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_20)
-if (MSVC)
-    target_compile_options(${LIBRARY_NAME} PRIVATE /permissive- /bigobj)
-else ()
-    target_compile_options(${LIBRARY_NAME} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wformat)
-endif ()
+target_compile_features(${CMAKE_PROJECT_NAME} PUBLIC cxx_std_20)
+configure_compiler_warnings(${CMAKE_PROJECT_NAME}
+    "${WARNINGS_AS_ERRORS}"
+    "${MSVC_WARNINGS}"
+    "${CLANG_WARNINGS}"
+    "${GCC_WARNINGS}")
 
 include(GNUInstallDirs)
-install(TARGETS ${LIBRARY_NAME}
-    EXPORT ${LIBRARY_NAME}-targets
+install(TARGETS ${CMAKE_PROJECT_NAME}
+    EXPORT ${CMAKE_PROJECT_NAME}-targets
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin)
@@ -119,20 +117,20 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/faker-cxx
     PATTERN "*.h"
 )
 
-install(EXPORT ${LIBRARY_NAME}-targets
-    NAMESPACE ${LIBRARY_NAME}::
-    FILE ${LIBRARY_NAME}-config.cmake
-    DESTINATION lib/cmake/${LIBRARY_NAME})
+install(EXPORT ${CMAKE_PROJECT_NAME}-targets
+    NAMESPACE ${CMAKE_PROJECT_NAME}::
+    FILE ${CMAKE_PROJECT_NAME}-config.cmake
+    DESTINATION lib/cmake/${CMAKE_PROJECT_NAME})
 
 if (HAS_STD_FORMAT AND NOT USE_SYSTEM_DEPENDENCIES)
-    target_compile_definitions(${LIBRARY_NAME} PRIVATE HAS_STD_FORMAT)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAS_STD_FORMAT)
 elseif (USE_SYSTEM_DEPENDENCIES)
     find_package(fmt REQUIRED)
-    target_link_libraries(${LIBRARY_NAME} PRIVATE fmt::fmt)
+    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE fmt::fmt)
 else ()
     add_subdirectory(externals/fmt)
     set(FMT_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/externals/fmt/include")
-    target_link_libraries(${LIBRARY_NAME} PRIVATE fmt)
+    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE fmt)
 endif ()
 
 if (BUILD_TESTING)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,0 +1,47 @@
+#
+# - configure_compiler_warnings
+#
+# This function configures compiler warnings for a given target. It supports MSVC, Clang and GCC compilers.
+# Most of content of warnings were collected from
+#
+function(configure_compiler_warnings TARGET_NAME WARNINGS_AS_ERRORS MSVC_WARNINGS CLANG_WARNINGS GCC_WARNINGS)
+  if(NOT MSVC_WARNINGS)
+    set(MSVC_WARNINGS /W4 /w14242 /w14254 /w14263 /w14265 /w14287 /we4289
+                      /w14296 /w14311 /w14545 /w14546 /w14547 /w14549 /w14555
+                      /w14619 /w14640 /w14826 /w14905 /w14906 /w14928
+                      /permissive- /bigobj)
+  endif()
+
+  if(NOT CLANG_WARNINGS)
+    set(CLANG_WARNINGS -Wall -Wextra -Wshadow -Wnon-virtual-dtor
+                       -Wold-style-cast -Wcast-align -Wunused
+                       -Woverloaded-virtual -Wpedantic -Wconversion
+                       -Wsign-conversion -Wnull-dereference -Wdouble-promotion
+                       -Wformat=2 -Wimplicit-fallthrough)
+  endif()
+
+  if(NOT GCC_WARNINGS)
+    set(GCC_WARNINGS ${CLANG_WARNINGS} -Wmisleading-indentation
+                     -Wduplicated-cond -Wduplicated-branches -Wlogical-op
+                     -Wuseless-cast -Wsuggest-override)
+  endif()
+
+  if(WARNINGS_AS_ERRORS)
+    message(AUTHOR_WARNING "Warnings are configured as errors!!!")
+    list(APPEND CLANG_WARNINGS -Werror)
+    list(APPEND GCC_WARNINGS -Werror)
+    list(APPEND MSVC_WARNINGS /WX)
+  endif()
+
+  if(MSVC)
+    set(PROJECT_WARNINGS_CXX ${MSVC_WARNINGS})
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    set(PROJECT_WARNINGS_CXX ${CLANG_WARNINGS})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(PROJECT_WARNINGS_CXX ${GCC_WARNINGS})
+  else()
+    message(AUTHOR_WARNING "No Warnings Configuration for Compiler ${CMAKE_CXX_COMPILER_ID}!!!")
+  endif()
+
+  target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${PROJECT_WARNINGS_CXX}>)
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 project(${CMAKE_PROJECT_NAME}-UT CXX)
 
 include(CTest)
+include("${CMAKE_SOURCE_DIR}/cmake/CompilerWarnings.cmake")
 
 set(FAKER_UT_SOURCES
     common/FormatHelperTest.cpp
@@ -45,9 +46,12 @@ set(FAKER_UT_SOURCES
 )
 
 add_executable(${PROJECT_NAME} ${FAKER_UT_SOURCES})
-if (MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /permissive- /bigobj)
-endif ()
+configure_compiler_warnings(${PROJECT_NAME}
+    "${WARNINGS_AS_ERRORS}"
+    "${MSVC_WARNINGS}"
+    "${CLANG_WARNINGS}"
+    "${GCC_WARNINGS}")
+
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/src/common


### PR DESCRIPTION
Adding compiler warning directly in CMakeLists.txt can be messy when you want to have multiple compilers supported and multiple warnings.

This PR follows the idea recommended by https://github.com/cpp-best-practices/ :

Use a separated CMake file with all compiler warnings, and export it as a function.

The function can receive compiler custom compiler flags too, so users will have a flexible build. The Warning as error is not enable by default, but can be when defining `-DWARNINGS_AS_ERRORS=ON` 