### PR TITLE
CI: Skip building when changing documentation only

### DIFF
--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/linux-static-analysis.yml
+++ b/.github/workflows/linux-static-analysis.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/macos-clang-build.yml
+++ b/.github/workflows/macos-clang-build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - 'main'
-
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'main'
       - 'ci/cache'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   workflow_dispatch:
   pull_request:
 


### PR DESCRIPTION
Hello!

This PR adds support of skipping the CI when changing only documentation and nothing more. For instance, when updating the README, or documentation folder (it only contains .md files).

I used the [paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) feature from Github Actions. 


closes #631