### PR TITLE
refactor words

### DIFF
--- a/include/faker-cxx/Helper.h
+++ b/include/faker-cxx/Helper.h
@@ -57,6 +57,19 @@ public:
         return data[index];
     }
 
+    template <typename It>
+    static auto arrayElement(It start, It end) -> decltype(*::std::declval<It>())
+    {
+        size_t size = end - start;
+        if (size == 0)
+        {
+            throw std::invalid_argument{"Range [start,end) is empty."};
+        }
+
+        const auto index = Number::integer<size_t>(size - 1);
+        return start[index];
+    }
+
     /**
      * @brief Get a random element from a vector.
      *

--- a/include/faker-cxx/Word.h
+++ b/include/faker-cxx/Word.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace faker
 {
@@ -21,7 +22,7 @@ public:
      * Word::sample(5) // "spell"
      * @endcode
      */
-    static std::string sample(std::optional<unsigned> length = std::nullopt);
+    static std::string_view sample(std::optional<unsigned> length = std::nullopt);
 
     /**
      * @brief Returns a string containing a number of space separated random words.
@@ -50,7 +51,7 @@ public:
      * Word::adjective(3) // "bad"
      * @endcode
      */
-    static std::string adjective(std::optional<unsigned> length = std::nullopt);
+    static std::string_view adjective(std::optional<unsigned> length = std::nullopt);
 
     /**
      * @brief Returns a random adverb.
@@ -65,7 +66,7 @@ public:
      * Word::adverb(5) // "almost"
      * @endcode
      */
-    static std::string adverb(std::optional<unsigned> length = std::nullopt);
+    static std::string_view adverb(std::optional<unsigned> length = std::nullopt);
 
     /**
      * @brief Returns a random conjunction.
@@ -80,7 +81,7 @@ public:
      * Word::conjunction(6) // "indeed"
      * @endcode
      */
-    static std::string conjunction(std::optional<unsigned> length = std::nullopt);
+    static std::string_view conjunction(std::optional<unsigned> length = std::nullopt);
 
     /**
      * @brief Returns a random interjection.
@@ -95,7 +96,7 @@ public:
      * Word::interjection(4) // "yuck"
      * @endcode
      */
-    static std::string interjection(std::optional<unsigned> length = std::nullopt);
+    static std::string_view interjection(std::optional<unsigned> length = std::nullopt);
 
     /**
      * @brief Returns a random noun.
@@ -110,7 +111,7 @@ public:
      * Word::noun(8) // "distance"
      * @endcode
      */
-    static std::string noun(std::optional<unsigned> length = std::nullopt);
+    static std::string_view noun(std::optional<unsigned> length = std::nullopt);
 
     /**
      * @brief Returns a random preposition.
@@ -125,7 +126,7 @@ public:
      * Word::preposition(4) // "from"
      * @endcode
      */
-    static std::string preposition(std::optional<unsigned> length = std::nullopt);
+    static std::string_view preposition(std::optional<unsigned> length = std::nullopt);
 
     /**
      * @brief Returns a random verb.
@@ -140,6 +141,6 @@ public:
      * Word::verb(9) // "stabilise"
      * @endcode
      */
-    static std::string verb(std::optional<unsigned> length = std::nullopt);
+    static std::string_view verb(std::optional<unsigned> length = std::nullopt);
 };
 }

--- a/src/common/FormatHelper.cpp
+++ b/src/common/FormatHelper.cpp
@@ -46,4 +46,43 @@ FormatHelper::fillTokenValues(const std::string& format,
 
     return filledFormat;
 }
+
+std::string
+FormatHelper::fillTokenValues(const std::string& format,
+                              std::unordered_map<std::string_view, std::function<std::string_view()>> tokenValueGenerators)
+{
+    std::string filledFormat;
+
+    int tokenStart = -1;
+
+    for (auto i = 0u; i < format.size(); i++)
+    {
+        if (format[i] == '{')
+        {
+            tokenStart = static_cast<int>(i) + 1;
+        }
+        else if (format[i] == '}' && tokenStart != -1 && static_cast<unsigned>(tokenStart) < i)
+        {
+            const auto token = format.substr(static_cast<unsigned>(tokenStart), i - static_cast<unsigned>(tokenStart));
+
+            const auto foundTokenGenerator = tokenValueGenerators.find(token);
+
+            if (foundTokenGenerator == tokenValueGenerators.end())
+            {
+                throw std::runtime_error{FormatHelper::format("Generator not found for token {}.", token)};
+            }
+
+            filledFormat += foundTokenGenerator->second();
+
+            tokenStart = -1;
+        }
+        else if (tokenStart == -1)
+        {
+            filledFormat += format[i];
+        }
+    }
+
+    return filledFormat;
+}
+
 }

--- a/src/common/FormatHelper.h
+++ b/src/common/FormatHelper.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -33,5 +34,8 @@ public:
     static std::string
     fillTokenValues(const std::string& format,
                     std::unordered_map<std::string, std::function<std::string()>> tokenValueGenerators);
+
+    static std::string fillTokenValues(const std::string& format,
+                    std::unordered_map<std::string_view, std::function<std::string_view()>> tokenValueGenerators);
 };
 }

--- a/src/modules/person/Person.cpp
+++ b/src/modules/person/Person.cpp
@@ -330,11 +330,11 @@ std::string Person::bio()
 {
     const auto randomBioFormat = static_cast<std::string>(Helper::arrayElement(bioFormats));
 
-    const std::unordered_map<std::string, std::function<std::string()>> dataGeneratorsMapping{
-        {"bio_part", []() { return std::string{Helper::arrayElement(bioParts)}; }},
-        {"bio_supporter", []() { return std::string{Helper::arrayElement(bioSupporters)}; }},
+    const std::unordered_map<std::string_view, std::function<std::string_view()>> dataGeneratorsMapping{
+        {"bio_part", []() { return Helper::arrayElement(bioParts); }},
+        {"bio_supporter", []() { return Helper::arrayElement(bioSupporters); }},
         {"noun", []() { return Word::noun(); }},
-        {"emoji", []() { return std::string{Internet::emoji()}; }}};
+        {"emoji", []() { return Internet::emoji(); }}};
 
     return FormatHelper::fillTokenValues(randomBioFormat, dataGeneratorsMapping);
 }

--- a/src/modules/word/Word.cpp
+++ b/src/modules/word/Word.cpp
@@ -1,199 +1,135 @@
 #include "faker-cxx/Word.h"
 
+#include <algorithm>
+#include <array>
 #include <optional>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "../../common/StringHelper.h"
-#include "data/Adjectives.h"
-#include "data/Adverbs.h"
-#include "data/Conjunctions.h"
-#include "data/Interjections.h"
-#include "data/Nouns.h"
-#include "data/Prepositions.h"
-#include "data/Verbs.h"
+#include "data/All.h"
 #include "faker-cxx/Helper.h"
 
 namespace faker
 {
-std::string Word::sample(std::optional<unsigned int> length)
+template <typename It>
+auto sortedSizeArrayElement(std::optional<unsigned int> length, It start, It end) -> decltype(*std::declval<It>())
 {
-    std::vector<std::string> allWords{adjectives};
-
-    allWords.insert(allWords.end(), adverbs.begin(), adverbs.end());
-    allWords.insert(allWords.end(), conjunctions.begin(), conjunctions.end());
-    allWords.insert(allWords.end(), interjections.begin(), interjections.end());
-    allWords.insert(allWords.end(), nouns.begin(), nouns.end());
-    allWords.insert(allWords.end(), prepositions.begin(), prepositions.end());
-    allWords.insert(allWords.end(), verbs.begin(), verbs.end());
-
     if (!length)
     {
-        return Helper::arrayElement<std::string>(allWords);
+        return Helper::arrayElement(start, end);
     }
 
-    const auto shuffledWords = Helper::shuffle(allWords);
+    size_t length_64 = *length;
+    auto lower_it = ::std::lower_bound(start, end, length_64,
+                                       [](const auto& lhs, const auto& value) { return lhs.size() < value; });
 
-    for (const auto& word : shuffledWords)
+    if (lower_it == end)
     {
-        if (word.size() == length)
-        {
-            return word;
-        }
+        return Helper::arrayElement(start, end);
     }
+    else
+    {
+        if (lower_it->size() != length)
+            return Helper::arrayElement(start, end);
 
-    return Helper::arrayElement<std::string>(shuffledWords);
+        auto upper_it = lower_it;
+        for (; upper_it != end; upper_it++)
+        {
+            if (upper_it->size() != lower_it->size())
+                break;
+        }
+        return Helper::arrayElement(lower_it, upper_it);
+    }
+}
+
+std::string_view Word::sample(std::optional<unsigned int> length)
+{
+    return sortedSizeArrayElement(length, _allWords.cbegin(), _allWords.cend());
 }
 
 std::string Word::words(unsigned numberOfWords)
 {
-    std::vector<std::string> words;
-
-    for (unsigned i = 0; i < numberOfWords; i++)
+    if (numberOfWords == 0)
     {
-        words.push_back(sample());
+        return "";
     }
 
-    return StringHelper::joinString(words, " ");
+    std::string combined_words;
+    if (numberOfWords <= 256)
+    {
+        std::array<unsigned int, 256> tmp; // fitting 1024 bytes worth of integers*
+        const size_t last_index = _allWords.size() - 1;
+        size_t reserve_size = 0;
+
+        for (unsigned i = 0; i < numberOfWords; i++)
+        {
+            tmp[i] = Number::integer<unsigned int>(last_index);
+            auto vw = _allWords[tmp[i]];
+            reserve_size += vw.size();
+        }
+
+        unsigned space_words = (numberOfWords - 1);
+        combined_words.reserve(reserve_size + (numberOfWords - 1));
+        for (unsigned i = 0; i < space_words; i++)
+        {
+            auto vw = _allWords[tmp[i]];
+            combined_words.append(vw.begin(), vw.end());
+            combined_words.push_back(' ');
+        }
+        auto vw = _allWords[tmp[numberOfWords - 1]];
+        combined_words.append(vw.begin(), vw.end());
+    }
+    else
+    {
+        unsigned space_words = (numberOfWords - 1);
+        for (unsigned i = 0; i < space_words; i++)
+        {
+            auto s = sample();
+            combined_words.append(s.begin(), s.end());
+            combined_words.push_back(' ');
+        }
+
+        auto s = sample();
+        combined_words.append(s.begin(), s.end());
+    }
+
+    return combined_words;
 }
 
-std::string Word::adjective(std::optional<unsigned int> length)
+std::string_view Word::adjective(std::optional<unsigned int> length)
 {
-    if (!length)
-    {
-        return Helper::arrayElement<std::string>(adjectives);
-    }
-
-    const auto shuffledAdjectives = Helper::shuffle(adjectives);
-
-    for (const auto& adjective : shuffledAdjectives)
-    {
-        if (adjective.size() == length)
-        {
-            return adjective;
-        }
-    }
-
-    return Helper::arrayElement<std::string>(shuffledAdjectives);
+    return sortedSizeArrayElement(length, _adjectives_sorted.cbegin(), _adjectives_sorted.cend());
 }
 
-std::string Word::adverb(std::optional<unsigned int> length)
+std::string_view Word::adverb(std::optional<unsigned int> length)
 {
-    if (!length)
-    {
-        return Helper::arrayElement<std::string>(adverbs);
-    }
-
-    const auto shuffledAdverbs = Helper::shuffle(adverbs);
-
-    for (const auto& adverb : shuffledAdverbs)
-    {
-        if (adverb.size() == length)
-        {
-            return adverb;
-        }
-    }
-
-    return Helper::arrayElement<std::string>(shuffledAdverbs);
+    return sortedSizeArrayElement(length, _adverbs_sorted.cbegin(), _adverbs_sorted.cend());
 }
 
-std::string Word::conjunction(std::optional<unsigned int> length)
+std::string_view Word::conjunction(std::optional<unsigned int> length)
 {
-    if (!length)
-    {
-        return Helper::arrayElement<std::string>(conjunctions);
-    }
-
-    const auto shuffledConjunctions = Helper::shuffle(conjunctions);
-
-    for (const auto& conjunction : shuffledConjunctions)
-    {
-        if (conjunction.size() == length)
-        {
-            return conjunction;
-        }
-    }
-
-    return Helper::arrayElement<std::string>(shuffledConjunctions);
+    return sortedSizeArrayElement(length, _conjunctions_sorted.cbegin(), _conjunctions_sorted.cend());
 }
 
-std::string Word::interjection(std::optional<unsigned int> length)
+std::string_view Word::interjection(std::optional<unsigned int> length)
 {
-    if (!length)
-    {
-        return Helper::arrayElement<std::string>(interjections);
-    }
-
-    const auto shuffledInterjections = Helper::shuffle(interjections);
-
-    for (const auto& interjection : shuffledInterjections)
-    {
-        if (interjection.size() == length)
-        {
-            return interjection;
-        }
-    }
-
-    return Helper::arrayElement<std::string>(shuffledInterjections);
+    return sortedSizeArrayElement(length, _interjections_sorted.cbegin(), _interjections_sorted.cend());
 }
 
-std::string Word::noun(std::optional<unsigned int> length)
+std::string_view Word::noun(std::optional<unsigned int> length)
 {
-    if (!length)
-    {
-        return Helper::arrayElement<std::string>(nouns);
-    }
-
-    const auto shuffledNouns = Helper::shuffle(nouns);
-
-    for (const auto& noun : shuffledNouns)
-    {
-        if (noun.size() == length)
-        {
-            return noun;
-        }
-    }
-
-    return Helper::arrayElement<std::string>(shuffledNouns);
+    return sortedSizeArrayElement(length, _nouns_sorted.cbegin(), _nouns_sorted.cend());
 }
 
-std::string Word::preposition(std::optional<unsigned int> length)
+std::string_view Word::preposition(std::optional<unsigned int> length)
 {
-    if (!length)
-    {
-        return Helper::arrayElement<std::string>(prepositions);
-    }
-
-    const auto shuffledPrepositions = Helper::shuffle(prepositions);
-
-    for (const auto& preposition : shuffledPrepositions)
-    {
-        if (preposition.size() == length)
-        {
-            return preposition;
-        }
-    }
-
-    return Helper::arrayElement<std::string>(shuffledPrepositions);
+    return sortedSizeArrayElement(length, _prepositions_sorted.cbegin(), _prepositions_sorted.cend());
 }
 
-std::string Word::verb(std::optional<unsigned int> length)
+std::string_view Word::verb(std::optional<unsigned int> length)
 {
-    if (!length)
-    {
-        return Helper::arrayElement<std::string>(verbs);
-    }
-
-    const auto shuffledVerbs = Helper::shuffle(verbs);
-
-    for (const auto& verb : shuffledVerbs)
-    {
-        if (verb.size() == length)
-        {
-            return verb;
-        }
-    }
-
-    return Helper::arrayElement<std::string>(shuffledVerbs);
+    return sortedSizeArrayElement(length, _verbs_sorted.cbegin(), _verbs_sorted.cend());
 }
 }

--- a/src/modules/word/data/Adjectives.h
+++ b/src/modules/word/data/Adjectives.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <array>
+#include <string_view>
 
 namespace faker
 {
-const std::vector<std::string> adjectives = {"abandoned",
+const std::array<std::string_view,1328> adjectives = {"abandoned",
                                              "able",
                                              "absolute",
                                              "adorable",

--- a/src/modules/word/data/Adverbs.h
+++ b/src/modules/word/data/Adverbs.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <array>
+#include <string_view>
 
 namespace faker
 {
-const std::vector<std::string> adverbs = {
+const std::array<std::string_view,325> adverbs = {
     "abnormally",
     "absentmindedly",
     "accidentally",

--- a/src/modules/word/data/All.h
+++ b/src/modules/word/data/All.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include "Adjectives.h"
+#include "Adverbs.h"
+#include "Conjunctions.h"
+#include "Interjections.h"
+#include "Nouns.h"
+#include "Prepositions.h"
+#include "Verbs.h"
+
+namespace faker
+{
+
+// https://tristanbrindle.com/posts/a-more-useful-compile-time-quicksort
+namespace cstd
+{
+template <typename RAIt>
+constexpr RAIt next(RAIt it, typename std::iterator_traits<RAIt>::difference_type n = 1)
+{
+    return it + n;
+}
+
+template <typename RAIt>
+constexpr auto distance(RAIt first, RAIt last)
+{
+    return last - first;
+}
+
+template <class ForwardIt1, class ForwardIt2>
+constexpr void iter_swap(ForwardIt1 a, ForwardIt2 b)
+{
+    auto temp = std::move(*a);
+    *a = std::move(*b);
+    *b = std::move(temp);
+}
+
+template <class InputIt, class UnaryPredicate>
+constexpr InputIt find_if_not(InputIt first, InputIt last, UnaryPredicate q)
+{
+    for (; first != last; ++first)
+    {
+        if (!q(*first))
+        {
+            return first;
+        }
+    }
+    return last;
+}
+
+template <class ForwardIt, class UnaryPredicate>
+constexpr ForwardIt partition(ForwardIt first, ForwardIt last, UnaryPredicate p)
+{
+    first = cstd::find_if_not(first, last, p);
+    if (first == last)
+        return first;
+
+    for (ForwardIt i = cstd::next(first); i != last; ++i)
+    {
+        if (p(*i))
+        {
+            cstd::iter_swap(i, first);
+            ++first;
+        }
+    }
+    return first;
+}
+} // namespace cstd
+
+template <class RAIt, class Compare = std::less<>>
+constexpr void quick_sort(RAIt first, RAIt last, Compare cmp = Compare{})
+{
+    auto const N = cstd::distance(first, last);
+    if (N <= 1)
+        return;
+    auto const pivot = *cstd::next(first, N / 2);
+    auto const middle1 = cstd::partition(first, last, [=](auto const& elem) { return cmp(elem, pivot); });
+    auto const middle2 = cstd::partition(middle1, last, [=](auto const& elem) { return !cmp(pivot, elem); });
+    quick_sort(first, middle1, cmp);
+    quick_sort(middle2, last, cmp);
+}
+
+const std::array<std::string_view, adjectives.size() + adverbs.size() + conjunctions.size() + interjections.size() +
+                                       nouns.size() + prepositions.size() + verbs.size()>
+    _allWords = []()
+{
+    std::array<std::string_view, adjectives.size() + adverbs.size() + conjunctions.size() + interjections.size() +
+                                     nouns.size() + prepositions.size() + verbs.size()>
+        table{};
+
+    size_t idx = 0;
+    for (const auto& v : adjectives)
+    {
+        table[idx] = v;
+        idx++;
+    }
+
+    for (const auto& v : adverbs)
+    {
+        table[idx] = v;
+        idx++;
+    }
+
+    for (const auto& v : conjunctions)
+    {
+        table[idx] = v;
+        idx++;
+    }
+
+    for (const auto& v : interjections)
+    {
+        table[idx] = v;
+        idx++;
+    }
+
+    for (const auto& v : nouns)
+    {
+        table[idx] = v;
+        idx++;
+    }
+
+    for (const auto& v : prepositions)
+    {
+        table[idx] = v;
+        idx++;
+    }
+
+    for (const auto& v : verbs)
+    {
+        table[idx] = v;
+        idx++;
+    }
+
+    quick_sort(table.begin(), table.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return table;
+}();
+
+const auto _adjectives_sorted = []()
+{
+    auto sorted = adjectives;
+    quick_sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return sorted;
+}();
+
+const auto _adverbs_sorted = []()
+{
+    auto sorted = adverbs;
+    quick_sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return sorted;
+}();
+
+const auto _conjunctions_sorted = []()
+{
+    auto sorted = conjunctions;
+    quick_sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return sorted;
+}();
+
+const auto _interjections_sorted = []()
+{
+    auto sorted = interjections;
+    quick_sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return sorted;
+}();
+
+const auto _nouns_sorted = []()
+{
+    auto sorted = nouns;
+    quick_sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return sorted;
+}();
+
+const auto _prepositions_sorted = []()
+{
+    auto sorted = prepositions;
+    quick_sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return sorted;
+}();
+
+const auto _verbs_sorted = []()
+{
+    auto sorted = verbs;
+    quick_sort(sorted.begin(), sorted.end(), [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); });
+    return sorted;
+}();
+}

--- a/src/modules/word/data/Conjunctions.h
+++ b/src/modules/word/data/Conjunctions.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <array>
+#include <string_view>
 
 namespace faker
 {
-const std::vector<std::string> conjunctions = {
+const std::array<std::string_view,51> conjunctions = {
     "after",    "although",     "and",      "as",          "because", "before",   "but",       "consequently",
     "even",     "finally",      "for",      "furthermore", "hence",   "how",      "however",   "if",
     "inasmuch", "incidentally", "indeed",   "instead",     "lest",    "likewise", "meanwhile", "nor",

--- a/src/modules/word/data/Interjections.h
+++ b/src/modules/word/data/Interjections.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <array>
+#include <string_view>
 
 namespace faker
 {
-const std::vector<std::string> interjections = {
+const std::array<std::string_view,46> interjections = {
     "yuck", "oh",     "phooey", "blah", "boo",  "whoa",  "yowza",    "huzzah", "boohoo", "fooey", "geez", "pfft",
     "ew",   "ah",     "yum",    "brr",  "hm",   "yahoo", "aha",      "woot",   "drat",   "gah",   "meh",  "psst",
     "aw",   "ugh",    "yippee", "eek",  "gee",  "bah",   "gadzooks", "duh",    "ha",     "mmm",   "ouch", "phew",

--- a/src/modules/word/data/Nouns.h
+++ b/src/modules/word/data/Nouns.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <array>
+#include <string_view>
 
 namespace faker
 {
-const std::vector<std::string> nouns = {"ATM",
+const std::array<std::string_view,6659> nouns = {"ATM",
                                         "CD",
                                         "SUV",
                                         "TV",

--- a/src/modules/word/data/Prepositions.h
+++ b/src/modules/word/data/Prepositions.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <array>
+#include <string_view>
 
 namespace faker
 {
-const std::vector<std::string> prepositions = {
+const std::array<std::string_view,109> prepositions = {
     "a",
     "abaft",
     "aboard",

--- a/src/modules/word/data/Verbs.h
+++ b/src/modules/word/data/Verbs.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <array>
+#include <string_view>
 
 namespace faker
 {
-const std::vector<std::string> verbs = {"abandon",
+const std::array<std::string_view,5910> verbs = {"abandon",
                                         "abase",
                                         "abate",
                                         "abbreviate",

--- a/tests/modules/internet/InternetTest.cpp
+++ b/tests/modules/internet/InternetTest.cpp
@@ -72,6 +72,7 @@ class InternetTest : public Test
 public:
     InternetTest()
     {
+        sortedAdjectivesDescendingBySize.assign(adjectives.cbegin(), adjectives.cend());
         std::sort(sortedAdjectivesDescendingBySize.begin(), sortedAdjectivesDescendingBySize.end(),
                   [](const std::string& first, const std::string& second) { return first.size() > second.size(); });
     }
@@ -95,11 +96,19 @@ public:
 
         const auto generatedNoun = domainWord.substr(foundAdjective->size() + 1);
 
-        ASSERT_TRUE(std::ranges::any_of(nouns, [generatedNoun](const std::string& noun)
-                                        { return generatedNoun == StringHelper::toLower(noun); }));
+        ASSERT_TRUE(std::ranges::any_of(nouns,
+                                        [generatedNoun](const std::string_view& noun)
+                                        {
+                                            if (generatedNoun.size() != noun.size())
+                                                return false;
+                                            for (size_t i = 0; i < noun.size(); i++)
+                                                if (std::tolower(noun[i]) != std::tolower(generatedNoun[i]))
+                                                    return false;
+                                            return true;
+                                        }));
     }
 
-    std::vector<std::string> sortedAdjectivesDescendingBySize{adjectives};
+    std::vector<std::string> sortedAdjectivesDescendingBySize;
 };
 
 TEST_F(InternetTest, shouldGenerateUsername)

--- a/tests/modules/word/WordTest.cpp
+++ b/tests/modules/word/WordTest.cpp
@@ -39,7 +39,7 @@ TEST_F(WordTest, shouldGenerateAdjective)
 {
     const auto generatedAdjective = Word::adjective();
 
-    ASSERT_TRUE(std::ranges::any_of(adjectives, [generatedAdjective](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(adjectives, [generatedAdjective](const std::string_view& word)
                                     { return word == generatedAdjective; }));
 }
 
@@ -47,7 +47,7 @@ TEST_F(WordTest, shouldGenerateAdjectiveWithExistingLength)
 {
     const auto generatedAdjective = Word::adjective(5);
 
-    ASSERT_TRUE(std::ranges::any_of(adjectives, [generatedAdjective](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(adjectives, [generatedAdjective](const std::string_view& word)
                                     { return word == generatedAdjective; }));
 }
 
@@ -55,7 +55,7 @@ TEST_F(WordTest, shouldGenerateAdjectiveWithNonExistingLength)
 {
     const auto generatedAdjective = Word::adjective(100);
 
-    ASSERT_TRUE(std::ranges::any_of(adjectives, [generatedAdjective](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(adjectives, [generatedAdjective](const std::string_view& word)
                                     { return word == generatedAdjective; }));
 }
 
@@ -64,7 +64,7 @@ TEST_F(WordTest, shouldGenerateAdverb)
     const auto generatedAdverb = Word::adverb();
 
     ASSERT_TRUE(
-        std::ranges::any_of(adverbs, [generatedAdverb](const std::string& word) { return word == generatedAdverb; }));
+        std::ranges::any_of(adverbs, [generatedAdverb](const std::string_view& word) { return word == generatedAdverb; }));
 }
 
 TEST_F(WordTest, shouldGenerateAdverbWithExistingLength)
@@ -72,7 +72,7 @@ TEST_F(WordTest, shouldGenerateAdverbWithExistingLength)
     const auto generatedAdverb = Word::adverb(5);
 
     ASSERT_TRUE(
-        std::ranges::any_of(adverbs, [generatedAdverb](const std::string& word) { return word == generatedAdverb; }));
+        std::ranges::any_of(adverbs, [generatedAdverb](const std::string_view& word) { return word == generatedAdverb; }));
 }
 
 TEST_F(WordTest, shouldGenerateAdverbWithNonExistingLength)
@@ -80,14 +80,14 @@ TEST_F(WordTest, shouldGenerateAdverbWithNonExistingLength)
     const auto generatedAdverb = Word::adverb(100);
 
     ASSERT_TRUE(
-        std::ranges::any_of(adverbs, [generatedAdverb](const std::string& word) { return word == generatedAdverb; }));
+        std::ranges::any_of(adverbs, [generatedAdverb](const std::string_view& word) { return word == generatedAdverb; }));
 }
 
 TEST_F(WordTest, shouldGenerateConjunction)
 {
     const auto generatedConjunction = Word::conjunction();
 
-    ASSERT_TRUE(std::ranges::any_of(conjunctions, [generatedConjunction](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(conjunctions, [generatedConjunction](const std::string_view& word)
                                     { return word == generatedConjunction; }));
 }
 
@@ -95,7 +95,7 @@ TEST_F(WordTest, shouldGenerateConjunctionWithExistingLength)
 {
     const auto generatedConjunction = Word::conjunction(5);
 
-    ASSERT_TRUE(std::ranges::any_of(conjunctions, [generatedConjunction](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(conjunctions, [generatedConjunction](const std::string_view& word)
                                     { return word == generatedConjunction; }));
 }
 
@@ -103,7 +103,7 @@ TEST_F(WordTest, shouldGenerateConjunctionWithNonExistingLength)
 {
     const auto generatedConjunction = Word::conjunction(100);
 
-    ASSERT_TRUE(std::ranges::any_of(conjunctions, [generatedConjunction](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(conjunctions, [generatedConjunction](const std::string_view& word)
                                     { return word == generatedConjunction; }));
 }
 
@@ -111,7 +111,7 @@ TEST_F(WordTest, shouldGenerateInterjection)
 {
     const auto generatedInterjection = Word::interjection();
 
-    ASSERT_TRUE(std::ranges::any_of(interjections, [generatedInterjection](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(interjections, [generatedInterjection](const std::string_view& word)
                                     { return word == generatedInterjection; }));
 }
 
@@ -119,7 +119,7 @@ TEST_F(WordTest, shouldGenerateInterjectionWithExistingLength)
 {
     const auto generatedInterjection = Word::interjection(5);
 
-    ASSERT_TRUE(std::ranges::any_of(interjections, [generatedInterjection](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(interjections, [generatedInterjection](const std::string_view& word)
                                     { return word == generatedInterjection; }));
 }
 
@@ -127,7 +127,7 @@ TEST_F(WordTest, shouldGenerateInterjectionWithNonExistingLength)
 {
     const auto generatedInterjection = Word::interjection(100);
 
-    ASSERT_TRUE(std::ranges::any_of(interjections, [generatedInterjection](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(interjections, [generatedInterjection](const std::string_view& word)
                                     { return word == generatedInterjection; }));
 }
 
@@ -135,28 +135,28 @@ TEST_F(WordTest, shouldGenerateNoun)
 {
     const auto generatedNoun = Word::noun();
 
-    ASSERT_TRUE(std::ranges::any_of(nouns, [generatedNoun](const std::string& word) { return word == generatedNoun; }));
+    ASSERT_TRUE(std::ranges::any_of(nouns, [generatedNoun](const std::string_view& word) { return word == generatedNoun; }));
 }
 
 TEST_F(WordTest, shouldGenerateNounWithExistingLength)
 {
     const auto generatedNoun = Word::noun(5);
 
-    ASSERT_TRUE(std::ranges::any_of(nouns, [generatedNoun](const std::string& word) { return word == generatedNoun; }));
+    ASSERT_TRUE(std::ranges::any_of(nouns, [generatedNoun](const std::string_view& word) { return word == generatedNoun; }));
 }
 
 TEST_F(WordTest, shouldGenerateNounWithNonExistingLength)
 {
     const auto generatedNoun = Word::noun(100);
 
-    ASSERT_TRUE(std::ranges::any_of(nouns, [generatedNoun](const std::string& word) { return word == generatedNoun; }));
+    ASSERT_TRUE(std::ranges::any_of(nouns, [generatedNoun](const std::string_view& word) { return word == generatedNoun; }));
 }
 
 TEST_F(WordTest, shouldGeneratePreposition)
 {
     const auto generatedPreposition = Word::preposition();
 
-    ASSERT_TRUE(std::ranges::any_of(prepositions, [generatedPreposition](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(prepositions, [generatedPreposition](const std::string_view& word)
                                     { return word == generatedPreposition; }));
 }
 
@@ -164,7 +164,7 @@ TEST_F(WordTest, shouldGeneratePrepositionWithExistingLength)
 {
     const auto generatedPreposition = Word::preposition(5);
 
-    ASSERT_TRUE(std::ranges::any_of(prepositions, [generatedPreposition](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(prepositions, [generatedPreposition](const std::string_view& word)
                                     { return word == generatedPreposition; }));
 }
 
@@ -172,7 +172,7 @@ TEST_F(WordTest, shouldGeneratePrepositionWithNonExistingLength)
 {
     const auto generatedPreposition = Word::preposition(100);
 
-    ASSERT_TRUE(std::ranges::any_of(prepositions, [generatedPreposition](const std::string& word)
+    ASSERT_TRUE(std::ranges::any_of(prepositions, [generatedPreposition](const std::string_view& word)
                                     { return word == generatedPreposition; }));
 }
 
@@ -180,21 +180,21 @@ TEST_F(WordTest, shouldGenerateVerb)
 {
     const auto generatedVerb = Word::verb();
 
-    ASSERT_TRUE(std::ranges::any_of(verbs, [generatedVerb](const std::string& word) { return word == generatedVerb; }));
+    ASSERT_TRUE(std::ranges::any_of(verbs, [generatedVerb](const std::string_view& word) { return word == generatedVerb; }));
 }
 
 TEST_F(WordTest, shouldGenerateVerbWithExistingLength)
 {
     const auto generatedVerb = Word::verb(5);
 
-    ASSERT_TRUE(std::ranges::any_of(verbs, [generatedVerb](const std::string& word) { return word == generatedVerb; }));
+    ASSERT_TRUE(std::ranges::any_of(verbs, [generatedVerb](const std::string_view& word) { return word == generatedVerb; }));
 }
 
 TEST_F(WordTest, shouldGenerateVerbWithNonExistingLength)
 {
     const auto generatedVerb = Word::verb(100);
 
-    ASSERT_TRUE(std::ranges::any_of(verbs, [generatedVerb](const std::string& word) { return word == generatedVerb; }));
+    ASSERT_TRUE(std::ranges::any_of(verbs, [generatedVerb](const std::string_view& word) { return word == generatedVerb; }));
 }
 
 TEST_F(WordTest, shouldGenerateSample)


### PR DESCRIPTION
Use `std::string_view` where possible except for `words()`. Avoid allocating and shuffling data! Adding a header to combine all data together, organized by length once. Functions rewritten to retrieve by length (binary search) if possible later.

NOTE: check formatting, I use tabs, this library uses spaces, I think I fixed them all.
When initialized all the data structures could be `constexpr` or `constinit`. I brought in a constexpr quicksort (not mine) because `std::sort` is not constexpr until c++20. 