### PR TITLE
feat: Build shared library on Windows

### DIFF
--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -79,13 +79,17 @@ jobs:
             -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON \
             -DUSE_STD_FORMAT:BOOL=ON \
             -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake \
-            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
+            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
 
       - name: Build
         run: cmake --build --preset=unixlike-clang-debug-${{ matrix.type }}
 
       - name: Test
         run: ctest --preset=unixlike-clang-debug-${{ matrix.type }}
+
+      - name: Install
+        run: cmake --build --preset=unixlike-gcc-debug-${{ matrix.type }} --target install
 
       - name: Examples
         run: |

--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -13,8 +13,11 @@ on:
 
 jobs:
   build:
-    name: ci-ubuntu-24.04-clang-18
+    name: ci-ubuntu-24.04-clang-18-${{ matrix.type }}
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        type: [static, shared]
 
     steps:
       - name: Checkout
@@ -66,7 +69,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S ${{github.workspace}} --preset=unixlike-clang-debug \
+          cmake -S ${{github.workspace}} --preset=unixlike-clang-debug-${{ matrix.type }} \
             -DCMAKE_C_COMPILER=/usr/bin/clang-18 \
             -DCMAKE_CXX_COMPILER=/usr/bin/clang++-18 \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -79,12 +82,12 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
 
       - name: Build
-        run: cmake --build --preset=unixlike-clang-debug
+        run: cmake --build --preset=unixlike-clang-debug-${{ matrix.type }}
 
       - name: Test
-        run: ctest --preset=unixlike-clang-debug
+        run: ctest --preset=unixlike-clang-debug-${{ matrix.type }}
 
       - name: Examples
         run: |
-          cmake --build --preset=unixlike-clang-debug --target run-faker-cxx-basic-example \
-          && cmake --build --preset=unixlike-clang-debug --target run-faker-cxx-person-example
+          cmake --build --preset=unixlike-clang-debug-${{ matrix.type }} --target run-faker-cxx-basic-example \
+          && cmake --build --preset=unixlike-clang-debug-${{ matrix.type }} --target run-faker-cxx-person-example

--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -79,8 +79,7 @@ jobs:
             -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON \
             -DUSE_STD_FORMAT:BOOL=ON \
             -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake \
-            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
 
       - name: Build
         run: cmake --build --preset=unixlike-clang-debug-${{ matrix.type }}
@@ -89,7 +88,7 @@ jobs:
         run: ctest --preset=unixlike-clang-debug-${{ matrix.type }}
 
       - name: Install
-        run: cmake --build --preset=unixlike-gcc-debug-${{ matrix.type }} --target install
+        run: cmake --build --preset=unixlike-clang-debug-${{ matrix.type }} --target install
 
       - name: Examples
         run: |

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -13,11 +13,12 @@ on:
 
 jobs:
   build:
-    name: ci-ubuntu-24.04-gcc-${{ matrix.gcc_version }}
+    name: ci-ubuntu-24.04-gcc-${{ matrix.gcc_version }}-${{ matrix.type }}
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         gcc_version: [12, 13]
+        type: [static, shared]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,7 +69,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset=unixlike-gcc-debug \
+          cmake -S . --preset=unixlike-gcc-debug-${{ matrix.type }} \
             -DCMAKE_C_COMPILER=gcc-${{ matrix.gcc_version }} \
             -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc_version }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -79,7 +80,7 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
 
       - name: Build
-        run: cmake --build --preset=unixlike-gcc-debug
+        run: cmake --build --preset=unixlike-gcc-debug-${{ matrix.type }}
 
       - name: Test
-        run: ctest --preset=unixlike-gcc-debug
+        run: ctest --preset=unixlike-gcc-debug-${{ matrix.type }}

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -77,10 +77,14 @@ jobs:
             -DUSE_STD_FORMAT:BOOL=ON \
             -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON \
             -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake \
-            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
 
       - name: Build
         run: cmake --build --preset=unixlike-gcc-debug-${{ matrix.type }}
 
       - name: Test
         run: ctest --preset=unixlike-gcc-debug-${{ matrix.type }}
+
+      - name: Install
+        run: cmake --build --preset=unixlike-gcc-debug-${{ matrix.type }} --target install

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -77,8 +77,7 @@ jobs:
             -DUSE_STD_FORMAT:BOOL=ON \
             -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON \
             -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake \
-            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
 
       - name: Build
         run: cmake --build --preset=unixlike-gcc-debug-${{ matrix.type }}

--- a/.github/workflows/linux-static-analysis.yml
+++ b/.github/workflows/linux-static-analysis.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build_project:
-    name: ci-ubuntu-24.04-build-clang
+    name: ci-ubuntu-24.04-build-clang-static
     runs-on: ubuntu-24.04
 
     steps:
@@ -66,7 +66,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S ${{github.workspace}} --preset=unixlike-clang-debug \
+          cmake -S ${{github.workspace}} --preset=unixlike-clang-debug-static \
             -DCMAKE_C_COMPILER=/usr/bin/clang-18 \
             -DCMAKE_CXX_COMPILER=/usr/bin/clang++-18 \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -78,10 +78,10 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
 
       - name: Build
-        run: cmake --build --preset=unixlike-clang-debug
+        run: cmake --build --preset=unixlike-clang-debug-static
 
       - name: Generate code coverage
-        working-directory: ${{github.workspace}}/build/unixlike-clang-debug
+        working-directory: ${{github.workspace}}/build/unixlike-clang-debug-static
         run: |
           ninja faker-ccov-all \
           && llvm-cov-18 show `cat ccov/binaries.list` -instr-profile=ccov/all-merged.profdata > coverage.txt \
@@ -139,8 +139,8 @@ jobs:
             --enable=warning \
             --enable=portability \
             --inline-suppr \
-            --cppcheck-build-dir=build/unixlike-clang-debug \
-            --project=build/unixlike-clang-debug/compile_commands.json
+            --cppcheck-build-dir=build/unixlike-clang-debug-static \
+            --project=build/unixlike-clang-debug-static/compile_commands.json
 
   clang_tidy:
     name: clang-tidy
@@ -171,7 +171,7 @@ jobs:
       - name: Run clang-tidy
         run: |
           run-clang-tidy \
-            -p build/unixlike-clang-debug \
+            -p build/unixlike-clang-debug-static \
             -header-filter="include/*" \
             -extra-arg="-std=gnu++20" || true
 

--- a/.github/workflows/macos-clang-build.yml
+++ b/.github/workflows/macos-clang-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     runs-on: macos-14
-    name: ci-macos-14-apple-clang-18
+    name: ci-macos-14-apple-clang-18-static
     env:
       CLANG18_PATH: /opt/homebrew/opt/llvm@18/bin/clang
 
@@ -77,17 +77,21 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset=unixlike-clang-debug \
+          cmake -S . --preset=unixlike-clang-debug-static \
             -DBUILD_TESTING:BOOL=ON \
             -DCMAKE_CXX_COMPILER=${{ env.CLANG18_PATH }}++ \
             -DCMAKE_C_COMPILER=${{ env.CLANG18_PATH }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DUSE_STD_FORMAT:BOOL=ON \
             -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON \
-            -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake
+            -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
 
       - name: Build
-        run: cmake --build --preset=unixlike-clang-debug
+        run: cmake --build --preset=unixlike-clang-debug-static
 
       - name: Test
-        run: ctest --preset=unixlike-clang-debug
+        run: ctest --preset=unixlike-clang-debug-static
+
+      - name: Install
+        run: cmake --build --preset=unixlike-gcc-debug-static --target install

--- a/.github/workflows/macos-clang-build.yml
+++ b/.github/workflows/macos-clang-build.yml
@@ -84,8 +84,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DUSE_STD_FORMAT:BOOL=ON \
             -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON \
-            -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+            -DCMAKE_TOOLCHAIN_FILE=build/Debug/generators/conan_toolchain.cmake
 
       - name: Build
         run: cmake --build --preset=unixlike-clang-debug-static
@@ -94,4 +93,4 @@ jobs:
         run: ctest --preset=unixlike-clang-debug-static
 
       - name: Install
-        run: cmake --build --preset=unixlike-gcc-debug-static --target install
+        run: cmake --build --preset=unixlike-clang-debug-static --target install

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -16,6 +16,9 @@ jobs:
   build:
     name: ci-windows-msvc-19
     runs-on: windows-latest
+    strategy:
+      matrix:
+        shared: [ON, OFF]
 
     steps:
       - name: Checkout
@@ -61,7 +64,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset=windows-msvc-debug -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON
+          cmake -S . --preset=windows-msvc-debug -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON -DBUILD_SHARED_LIBS:BOOOL=${{ matrix.shared }}
 
       - name: Build
         run: cmake --build --preset=windows-msvc-debug

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -14,11 +14,11 @@ on:
 
 jobs:
   build:
-    name: ci-windows-msvc-19-shared-${{ matrix.shared }}
+    name: ci-windows-msvc-19-${{ matrix.type }}
     runs-on: windows-latest
     strategy:
       matrix:
-        shared: [ON, OFF]
+        type: [static, shared]
 
     steps:
       - name: Checkout
@@ -64,10 +64,10 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset=windows-msvc-debug -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON -DBUILD_SHARED_LIBS:BOOOL=${{ matrix.shared }}
+          cmake -S . --preset=windows-msvc-debug-${{ matrix.type }} -G Ninja -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON
 
       - name: Build
-        run: cmake --build --preset=windows-msvc-debug
+        run: cmake --build --preset=windows-msvc-debug-${{ matrix.type }}
 
       - name: Test
-        run: ctest --preset=windows-msvc-debug
+        run: ctest --preset=windows-msvc-debug-${{ matrix.type }}

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: ci-windows-msvc-19
+    name: ci-windows-msvc-19-shared-${{ matrix.shared }}
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -64,10 +64,13 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset=windows-msvc-debug-${{ matrix.type }} -G Ninja -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON
+          cmake -S . --preset=windows-msvc-debug-${{ matrix.type }} -G Ninja -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\install -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON
 
       - name: Build
         run: cmake --build --preset=windows-msvc-debug-${{ matrix.type }}
 
       - name: Test
         run: ctest --preset=windows-msvc-debug-${{ matrix.type }}
+
+      - name: Install
+        run: cmake --build --preset=windows-msvc-debug-${{ matrix.type }} --target install

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . --preset=windows-msvc-debug-${{ matrix.type }} -G Ninja -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\install -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON
+          cmake -S . --preset=windows-msvc-debug-${{ matrix.type }} -G Ninja -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\build\Debug\generators\conan_toolchain.cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl.exe -DBUILD_TESTING:BOOL=ON -DUSE_STD_FORMAT:BOOL=ON -DUSE_SYSTEM_DEPENDENCIES:BOOL=ON
 
       - name: Build
         run: cmake --build --preset=windows-msvc-debug-${{ matrix.type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ if (BUILD_TESTING)
     add_code_coverage_all_targets()
 endif ()
 
+file(GLOB_RECURSE HEADER_FILES "src/modules/**/*.h" "src/modules/**/*.h")
+
 set(FAKER_SOURCES
     src/modules/airline/Airline.cpp
     src/modules/animal/Animal.cpp
@@ -62,12 +64,13 @@ set(FAKER_SOURCES
     src/common/StringHelper.cpp
 )
 
-add_library(${CMAKE_PROJECT_NAME} ${FAKER_SOURCES})
+add_library(${CMAKE_PROJECT_NAME} ${FAKER_SOURCES} ${HEADER_FILES})
 
 target_include_directories(
     ${CMAKE_PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+    $<INSTALL_INTERFACE:include>
+)
 
 target_include_directories(
     ${CMAKE_PROJECT_NAME} PRIVATE
@@ -81,15 +84,29 @@ configure_compiler_warnings(${CMAKE_PROJECT_NAME}
     "${CLANG_WARNINGS}"
     "${GCC_WARNINGS}")
 
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES
+)
+
+include(GenerateExportHeader)
+generate_export_header(${CMAKE_PROJECT_NAME} BASE_NAME FAKER_CXX EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/include/faker-cxx/Export.h)
+
+target_include_directories(
+    ${CMAKE_PROJECT_NAME}
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/include
+)
+
 include(GNUInstallDirs)
 install(TARGETS ${CMAKE_PROJECT_NAME}
     EXPORT ${CMAKE_PROJECT_NAME}-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/faker-cxx
-    DESTINATION include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING
     PATTERN "*.h"
 )
@@ -102,7 +119,7 @@ install(EXPORT ${CMAKE_PROJECT_NAME}-targets
 if (HAS_STD_FORMAT)
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAS_STD_FORMAT)
 elseif (USE_SYSTEM_DEPENDENCIES)
-    find_package(fmt REQUIRED)
+    find_package(fmt CONFIG REQUIRED)
     target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE fmt::fmt)
 else ()
     add_subdirectory(externals/fmt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,6 @@ if (BUILD_TESTING)
     add_code_coverage_all_targets()
 endif ()
 
-file(GLOB_RECURSE HEADER_FILES "src/modules/**/*.h" "src/modules/**/*.h")
-
 set(FAKER_SOURCES
     src/modules/airline/Airline.cpp
     src/modules/animal/Animal.cpp
@@ -64,7 +62,7 @@ set(FAKER_SOURCES
     src/common/StringHelper.cpp
 )
 
-add_library(${CMAKE_PROJECT_NAME} ${FAKER_SOURCES} ${HEADER_FILES})
+add_library(${CMAKE_PROJECT_NAME} ${FAKER_SOURCES})
 
 target_include_directories(
     ${CMAKE_PROJECT_NAME} PUBLIC
@@ -106,6 +104,12 @@ install(TARGETS ${CMAKE_PROJECT_NAME}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/faker-cxx
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING
+    PATTERN "*.h"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/faker-cxx
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING
     PATTERN "*.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,10 @@ configure_compiler_warnings(${CMAKE_PROJECT_NAME}
 
 include(GenerateExportHeader)
 generate_export_header(${CMAKE_PROJECT_NAME} BASE_NAME FAKER_CXX EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/include/faker-cxx/Export.h)
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    CMAKE_VISIBILITY_INLINES_HIDDEN 1
+)
 
 target_include_directories(
     ${CMAKE_PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,11 +82,6 @@ configure_compiler_warnings(${CMAKE_PROJECT_NAME}
     "${CLANG_WARNINGS}"
     "${GCC_WARNINGS}")
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
-    CXX_VISIBILITY_PRESET hidden
-    VISIBILITY_INLINES_HIDDEN YES
-)
-
 include(GenerateExportHeader)
 generate_export_header(${CMAKE_PROJECT_NAME} BASE_NAME FAKER_CXX EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/include/faker-cxx/Export.h)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,6 +12,7 @@
             "hidden": true,
             "binaryDir": "${sourceDir}/build/${presetName}",
             "installDir": "${sourceDir}/install/${presetName}",
+            "generator": "Ninja",
             "cacheVariables": {
                 "USE_SYSTEM_DEPENDENCIES": "FALSE",
                 "USE_STD_FORMAT": "TRUE",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,6 @@
             "name": "conf-common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
-            "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "installDir": "${sourceDir}/install/${presetName}",
             "cacheVariables": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -292,84 +292,96 @@
             "displayName": "Strict",
             "description": "Validate Windows MSVC Static Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-debug-static"
+            "configurePreset": "windows-msvc-debug-static",
+            "configuration": "Debug"
         },
         {
             "name": "windows-msvc-debug-shared",
             "displayName": "Strict",
             "description": "Validate Windows MSVC Shared Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-debug-shared"
+            "configurePreset": "windows-msvc-debug-shared",
+            "configuration": "Debug"
         },
         {
             "name": "windows-msvc-release-static",
             "displayName": "Strict",
             "description": "Validate Windows MSVC Static Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-release-static"
+            "configurePreset": "windows-msvc-release-static",
+            "configuration": "Release"
         },
         {
             "name": "windows-msvc-release-shared",
             "displayName": "Strict",
             "description": "Validate Windows MSVC Shared Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-release-shared"
+            "configurePreset": "windows-msvc-release-shared",
+            "configuration": "Release"
         },
         {
             "name": "unixlike-gcc-debug-static",
             "displayName": "Strict",
             "description": "Validate Unixlike GCC Static Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-debug-static"
+            "configurePreset": "unixlike-gcc-debug-static",
+            "configuration": "Debug"
         },
         {
             "name": "unixlike-gcc-debug-shared",
             "displayName": "Strict",
             "description": "Validate Unixlike GCC Static Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-debug-shared"
+            "configurePreset": "unixlike-gcc-debug-shared",
+            "configuration": "Debug"
         },
         {
             "name": "unixlike-gcc-release-static",
             "displayName": "Strict",
             "description": "Validate Unixlike Clang Static Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-release-static"
+            "configurePreset": "unixlike-gcc-release-static",
+            "configuration": "Release"
         },
         {
             "name": "unixlike-gcc-release-shared",
             "displayName": "Strict",
             "description": "Validate Unixlike GCC Shared Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-release-shared"
+            "configurePreset": "unixlike-gcc-release-shared",
+            "configuration": "Release"
         },
         {
             "name": "unixlike-clang-debug-static",
             "displayName": "Strict",
             "description": "Validate Unixlike Clang Static Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-clang-debug-static"
+            "configurePreset": "unixlike-clang-debug-static",
+            "configuration": "Debug"
         },
         {
             "name": "unixlike-clang-debug-shared",
             "displayName": "Strict",
             "description": "Validate Unixlike Clang Shared Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-clang-debug-shared"
+            "configurePreset": "unixlike-clang-debug-shared",
+            "configuration": "Debug"
         },
         {
             "name": "unixlike-clang-release-static",
             "displayName": "Strict",
             "description": "Validate Unixlike Clang Static Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-clang-release-static"
+            "configurePreset": "unixlike-clang-release-static",
+            "configuration": "Release"
         },
         {
             "name": "unixlike-clang-release-shared",
             "displayName": "Strict",
             "description": "Validate Unixlike Clang Shared Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-clang-release-shared"
+            "configurePreset": "unixlike-clang-release-shared",
+            "configuration": "Release"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,109 +52,225 @@
             }
         },
         {
-            "name": "windows-msvc-debug",
-            "displayName": "msvc Debug ",
-            "description": "Target Windows with the msvc compiler, debug build type",
+            "name": "windows-msvc-debug-static",
+            "displayName": "Windows MSVC Debug Static",
+            "description": "Target Windows with the msvc compiler, debug build type, static library",
             "inherits": "conf-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl.exe",
                 "CMAKE_CXX_COMPILER": "cl.exe",
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_SHARED_LIBS": "OFF"
             }
         },
         {
-            "name": "windows-msvc-release",
-            "displayName": "msvc Release",
-            "description": "Target Windows with the msvc compiler, release build type",
+            "name": "windows-msvc-debug-shared",
+            "displayName": "Windows MSVC Debug Shared",
+            "description": "Target Windows with the msvc compiler, debug build type, shared library",
             "inherits": "conf-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl.exe",
                 "CMAKE_CXX_COMPILER": "cl.exe",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_SHARED_LIBS": "ON"
             }
         },
         {
-            "name": "unixlike-gcc-debug",
-            "displayName": "gcc Debug",
-            "description": "Target Unix-like OS with the gcc compiler, debug build type",
+            "name": "windows-msvc-release-static",
+            "displayName": "Windows MSVC Release Static",
+            "description": "Target Windows with the msvc compiler, release build type, static library",
+            "inherits": "conf-windows-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "BUILD_SHARED_LIBS": "OFF"
+            }
+        },
+        {
+            "name": "windows-msvc-release-shared",
+            "displayName": "Windows MSVC Release Shared",
+            "description": "Target Windows with the msvc compiler, release build type, shared library",
+            "inherits": "conf-windows-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "BUILD_SHARED_LIBS": "ON"
+            }
+        },
+        {
+            "name": "unixlike-gcc-debug-static",
+            "displayName": "Unixlike GCC Debug Static",
+            "description": "Target Unix-like OS with the gcc compiler, debug build type, static library",
             "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_SHARED_LIBS": "OFF"
             }
         },
         {
-            "name": "unixlike-gcc-release",
-            "displayName": "gcc Release",
-            "description": "Target Unix-like OS with the gcc compiler, release build type",
+            "name": "unixlike-gcc-debug-shared",
+            "displayName": "Unixlike GCC Debug Shared",
+            "description": "Target Unix-like OS with the gcc compiler, debug build type, shared library",
             "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_SHARED_LIBS": "ON"
             }
         },
         {
-            "name": "unixlike-clang-debug",
-            "displayName": "clang Debug",
-            "description": "Target Unix-like OS with the clang compiler, debug build type",
+            "name": "unixlike-gcc-release-static",
+            "displayName": "Unixlike GCC Release Static",
+            "description": "Target Unix-like OS with the gcc compiler, release build type, static library",
+            "inherits": "conf-unixlike-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_SHARED_LIBS": "OFF"
+            }
+        },
+        {
+            "name": "unixlike-gcc-release-shared",
+            "displayName": "Unixlike GCC Release Shared",
+            "description": "Target Unix-like OS with the gcc compiler, release build type, shared library",
+            "inherits": "conf-unixlike-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_SHARED_LIBS": "ON"
+            }
+        },
+        {
+            "name": "unixlike-clang-debug-static",
+            "displayName": "Unixlike Clang Debug Static",
+            "description": "Target Unix-like OS with the clang compiler, debug build type, static library",
             "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "BUILD_SHARED_LIBS": "OFF"
             }
         },
         {
-            "name": "unixlike-clang-release",
-            "displayName": "clang Release",
-            "description": "Target Unix-like OS with the clang compiler, release build type",
+            "name": "unixlike-clang-debug-shared",
+            "displayName": "Unixlike Clang Debug Shared",
+            "description": "Target Unix-like OS with the clang compiler, debug build type, shared library",
+            "inherits": "conf-unixlike-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "BUILD_SHARED_LIBS": "ON"
+            }
+        },
+        {
+            "name": "unixlike-clang-release-static",
+            "displayName": "Unixlike Clang Release Static",
+            "description": "Target Unix-like OS with the clang compiler, release build type, static library",
             "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "BUILD_SHARED_LIBS": "OFF"
+            }
+        },
+        {
+            "name": "unixlike-clang-release-shared",
+            "displayName": "Unixlike Clang Release Shared",
+            "description": "Target Unix-like OS with the clang compiler, release build type, shared library",
+            "inherits": "conf-unixlike-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "BUILD_SHARED_LIBS": "ON"
             }
         }
     ],
     "buildPresets": [
         {
-            "name": "unixlike-gcc-release",
-            "displayName": "Library Release Build",
-            "configurePreset": "unixlike-gcc-release",
+            "name": "unixlike-gcc-release-static",
+            "displayName": "Static Library Release Build",
+            "configurePreset": "unixlike-gcc-release-static",
             "configuration": "Release"
         },
         {
-            "name": "unixlike-gcc-debug",
-            "displayName": "Library Debug Build",
-            "configurePreset": "unixlike-gcc-debug",
+            "name": "unixlike-gcc-release-shared",
+            "displayName": "Shared Library Release Build",
+            "configurePreset": "unixlike-gcc-release-shared",
+            "configuration": "Release"
+        },
+        {
+            "name": "unixlike-gcc-debug-static",
+            "displayName": "Static Library Debug Build",
+            "configurePreset": "unixlike-gcc-debug-static",
             "configuration": "Debug"
         },
         {
-            "name": "unixlike-clang-release",
-            "displayName": "Library Release Build",
-            "configurePreset": "unixlike-clang-release",
-            "configuration": "Release"
-        },
-        {
-            "name": "unixlike-clang-debug",
-            "displayName": "Library Debug Build",
-            "configurePreset": "unixlike-clang-debug",
+            "name": "unixlike-gcc-debug-shared",
+            "displayName": "Shared Library Debug Build",
+            "configurePreset": "unixlike-gcc-debug-shared",
             "configuration": "Debug"
         },
         {
-            "name": "windows-msvc-release",
-            "displayName": "Library Release Build",
-            "configurePreset": "windows-msvc-release",
+            "name": "unixlike-clang-release-static",
+            "displayName": "Static Library Release Build",
+            "configurePreset": "unixlike-clang-release-static",
             "configuration": "Release"
         },
         {
-            "name": "windows-msvc-debug",
-            "displayName": "Library Debug Build",
-            "configurePreset": "windows-msvc-debug",
+            "name": "unixlike-clang-release-shared",
+            "displayName": "Shared Library Release Build",
+            "configurePreset": "unixlike-clang-release-shared",
+            "configuration": "Release"
+        },
+        {
+            "name": "unixlike-clang-debug-static",
+            "displayName": "Static Library Debug Build",
+            "configurePreset": "unixlike-clang-debug-static",
+            "configuration": "Debug"
+        },
+        {
+            "name": "unixlike-clang-debug-shared",
+            "displayName": "Shared Library Debug Build",
+            "configurePreset": "unixlike-clang-debug-shared",
+            "configuration": "Debug"
+        },
+        {
+            "name": "windows-msvc-release-static",
+            "displayName": "Static Library Release Build",
+            "configurePreset": "windows-msvc-release-static",
+            "configuration": "Release"
+        },
+        {
+            "name": "windows-msvc-release-shared",
+            "displayName": "Shared Library Release Build",
+            "configurePreset": "windows-msvc-release-shared",
+            "configuration": "Release"
+        },
+        {
+            "name": "windows-msvc-debug-static",
+            "displayName": "Static Library Debug Build",
+            "configurePreset": "windows-msvc-debug-static",
+            "configuration": "Debug"
+        },
+        {
+            "name": "windows-msvc-debug-shared",
+            "displayName": "Shared Library Debug Build",
+            "configurePreset": "windows-msvc-debug-shared",
             "configuration": "Debug"
         }
       ],
@@ -172,46 +288,88 @@
             }
         },
         {
-            "name": "windows-msvc-debug",
+            "name": "windows-msvc-debug-static",
             "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "description": "Validate Windows MSVC Static Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-debug"
+            "configurePreset": "windows-msvc-debug-static"
         },
         {
-            "name": "windows-msvc-release",
+            "name": "windows-msvc-debug-shared",
             "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "description": "Validate Windows MSVC Shared Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-release"
+            "configurePreset": "windows-msvc-debug-shared"
         },
         {
-            "name": "unixlike-gcc-debug",
+            "name": "windows-msvc-release-static",
             "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "description": "Validate Windows MSVC Static Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-debug"
+            "configurePreset": "windows-msvc-release-static"
         },
         {
-            "name": "unixlike-gcc-release",
+            "name": "windows-msvc-release-shared",
             "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "description": "Validate Windows MSVC Shared Library Release Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-release"
+            "configurePreset": "windows-msvc-release-shared"
         },
         {
-            "name": "unixlike-clang-debug",
+            "name": "unixlike-gcc-debug-static",
             "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "description": "Validate Unixlike GCC Static Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-clang-debug"
+            "configurePreset": "unixlike-gcc-debug-static"
         },
         {
-            "name": "unixlike-clang-release",
+            "name": "unixlike-gcc-debug-shared",
             "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "description": "Validate Unixlike GCC Static Library Debug Build",
             "inherits": "test-common",
-            "configurePreset": "unixlike-clang-release"
+            "configurePreset": "unixlike-gcc-debug-shared"
+        },
+        {
+            "name": "unixlike-gcc-release-static",
+            "displayName": "Strict",
+            "description": "Validate Unixlike Clang Static Library Release Build",
+            "inherits": "test-common",
+            "configurePreset": "unixlike-gcc-release-static"
+        },
+        {
+            "name": "unixlike-gcc-release-shared",
+            "displayName": "Strict",
+            "description": "Validate Unixlike GCC Shared Library Release Build",
+            "inherits": "test-common",
+            "configurePreset": "unixlike-gcc-release-shared"
+        },
+        {
+            "name": "unixlike-clang-debug-static",
+            "displayName": "Strict",
+            "description": "Validate Unixlike Clang Static Library Debug Build",
+            "inherits": "test-common",
+            "configurePreset": "unixlike-clang-debug-static"
+        },
+        {
+            "name": "unixlike-clang-debug-shared",
+            "displayName": "Strict",
+            "description": "Validate Unixlike Clang Shared Library Debug Build",
+            "inherits": "test-common",
+            "configurePreset": "unixlike-clang-debug-shared"
+        },
+        {
+            "name": "unixlike-clang-release-static",
+            "displayName": "Strict",
+            "description": "Validate Unixlike Clang Static Library Release Build",
+            "inherits": "test-common",
+            "configurePreset": "unixlike-clang-release-static"
+        },
+        {
+            "name": "unixlike-clang-release-shared",
+            "displayName": "Strict",
+            "description": "Validate Unixlike Clang Shared Library Release Build",
+            "inherits": "test-common",
+            "configurePreset": "unixlike-clang-release-shared"
         }
     ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,31 +107,37 @@ Follow the steps below to build the project:
 
     ```sh
     cmake --list-presets
-    "unixlike-gcc-debug"     - gcc Debug
-    "unixlike-gcc-release"   - gcc Release
-    "unixlike-clang-debug"   - clang Debug
-    "unixlike-clang-release" - clang Release
-    "windows-msvc-release"   - msvc Release
-    "windows-msvc-release"   - msvc Debug
+    "unixlike-gcc-debug-static"     - Unixlike GCC Debug Static library
+    "unixlike-gcc-debug-shared"     - Unixlike GCC Debug Shared library
+    "unixlike-gcc-release-static"   - Unixlike GCC Release Static library
+    "unixlike-gcc-release-shared"   - Unixlike GCC Release Shared library
+    "unixlike-clang-debug-static"   - Unixlike Clang Debug Static library
+    "unixlike-clang-debug-shared"   - Unixlike Clang Debug Shared library
+    "unixlike-clang-release-static" - Unixlike Clang Release Static library
+    "unixlike-clang-release-shared" - Unixlike Clang Release Shared library
+    "windows-msvc-debug-static"     - Windows MSVC Debug Static library
+    "windows-msvc-debug-shared"     - Windows MSVC Debug Shared library
+    "windows-msvc-release-static"   - Windows MSVC Release Static library
+    "windows-msvc-release-shared"   - Windows MSVC Release Shared library
     ```
 
-   For instance, if you are in Ubuntu and want to build using GCC in Debug mode, you should use the
-   preset `unixlike-gcc-debug`. The `unixlike-clang-` preset should work for both Linux and macOS when using the CLang
+   For instance, if you are in Ubuntu and want to build using GCC in Debug mode and static library (faker-cxx.a), you should use the
+   preset `unixlike-gcc-debug=static`. The `unixlike-clang-` preset should work for both Linux and macOS when using the CLang
    compiler.
 
    The `-S .` option in the following command specifies the source directory:
 
     ```sh
-    cmake -S . --preset unixlike-gcc-debug
+    cmake -S . --preset unixlike-gcc-debug-static
     ```
 
 3. **Build the project:**
 
    The following command generates the build files and compiles the project using the settings specified in
-   the `unixlike-gcc-debug` preset:
+   the `unixlike-gcc-debug-static` preset:
 
     ```sh
-    cmake --build --preset unixlike-gcc-debug
+    cmake --build --preset unixlike-gcc-debug-static
     ```
 
 ### Testing the Project
@@ -142,8 +148,28 @@ tests. Follow the steps below to test the project:
 **1. Run the tests using the same preset:**
 
     ```sh
-    ctest --preset unixlike-gcc-debug
+    ctest --preset unixlike-gcc-debug-static
     ```
+
+### Installing the Project
+
+When wanting to install those generated artifacts like headers files and library, you can use CMake to operate as installer as well:
+
+   ```sh
+      cmake --build --preset unixlike-gcc-debug-static --target install
+   ```
+
+By default, CMake will install in the subfolder `install` in the source folder.
+
+In order to change the installation folder, you can use [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html) to configure the destination folder:
+
+   ```sh
+      cmake -S . --preset unixlike-gcc-debug-static -DCMAKE_INSTALL_PREFIX=/opt/faker-cxx
+      cmake --build --preset unixlike-gcc-debug-static --target install
+   ```
+
+This configuration will install all artifacts in `/opt/faker-cxx`. The permission to write in the folder should be granted before executing the installation command.
+
 
 ## Submitting Changes
 
@@ -186,7 +212,7 @@ PR titles are written in following convention: `type: subject`
 
 **type** is required and indicates the intent of the PR
 
-> The types `feat` and `fix` will be shown in the changelog as `### Features` or `### Bug Fixes`  
+> The types `feat` and `fix` will be shown in the changelog as `### Features` or `### Bug Fixes`
 
 Allowed types are:
 

--- a/include/faker-cxx/Airline.h
+++ b/include/faker-cxx/Airline.h
@@ -67,7 +67,7 @@ namespace faker::airline
      */
     FAKER_CXX_EXPORT Airport airport();
 
-    enum class FAKER_CXX_EXPORT AircraftType
+    enum class AircraftType
     {
         Regional,
         Narrowbody,

--- a/include/faker-cxx/Airline.h
+++ b/include/faker-cxx/Airline.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::airline
 {
-        /**
+    /**
      * @brief Get a random aircraft type
      *
      * @return a random aircraft type
@@ -13,9 +14,9 @@ namespace faker::airline
      * faker::airline::aircraftType // "narrowbody"
      * @endcode
      */
-    std::string_view aircraftType();
+    FAKER_CXX_EXPORT std::string_view aircraftType();
 
-    struct Airplane
+    struct FAKER_CXX_EXPORT Airplane
     {
         std::string_view name;
         std::string_view iataTypeCode;
@@ -30,9 +31,9 @@ namespace faker::airline
      * faker::airline::airplane() // {"Boeing 737-800", "738"}
      * @endcode
      */
-     Airplane airplane();
+    FAKER_CXX_EXPORT Airplane airplane();
 
-    struct AirlineInfo
+    struct FAKER_CXX_EXPORT AirlineInfo
     {
         std::string_view name;
         std::string_view iataCode;
@@ -47,9 +48,9 @@ namespace faker::airline
      * faker::airline::airline() // {"Air Canada", "AC"}
      * @endcode
      */
-     AirlineInfo airline();
+    FAKER_CXX_EXPORT AirlineInfo airline();
 
-    struct Airport
+    struct FAKER_CXX_EXPORT Airport
     {
         std::string_view name;
         std::string_view iataCode;
@@ -64,9 +65,9 @@ namespace faker::airline
      * faker::airline::airport() // {"Toronto Pearson International Airport", "YYZ"}
      * @endcode
      */
-     Airport airport();
+    FAKER_CXX_EXPORT Airport airport();
 
-    enum class AircraftType
+    enum class FAKER_CXX_EXPORT AircraftType
     {
         Regional,
         Narrowbody,
@@ -84,7 +85,7 @@ namespace faker::airline
      * faker::airline::seat(AircraftType::Narrowbody) // "1A"
      * @endcode
      */
-     std::string seat(AircraftType aircraftType);
+    FAKER_CXX_EXPORT std::string seat(AircraftType aircraftType);
 
     /**
      * @brief Get a random record location
@@ -96,7 +97,7 @@ namespace faker::airline
      * faker::airline::recordLocator(true) // "ABC123"
      * @endcode
      */
-     std::string recordLocator(bool allowNumerics = false);
+    FAKER_CXX_EXPORT std::string recordLocator(bool allowNumerics = false);
 
     /**
      * @brief Get a random flight number from given length
@@ -113,9 +114,9 @@ namespace faker::airline
      * faker::airline::flightNumber(false, 3) // "234"
      * @endcode
      */
-     std::string flightNumber(bool addLeadingZeros = false, unsigned int length = 4);
+    FAKER_CXX_EXPORT std::string flightNumber(bool addLeadingZeros = false, unsigned int length = 4);
 
-    struct Range
+    struct FAKER_CXX_EXPORT Range
     {
         unsigned int min;
         unsigned int max;
@@ -136,5 +137,5 @@ namespace faker::airline
      * faker::airline::flightNumber(false, {1, 4}) // "234" // "12" // "1234"
      * @endcode
      */
-     std::string flightNumberByRange(bool addLeadingZeros = false, Range length = {1, 4});
-    }
+    FAKER_CXX_EXPORT std::string flightNumberByRange(bool addLeadingZeros = false, Range length = {1, 4});
+}

--- a/include/faker-cxx/Animal.h
+++ b/include/faker-cxx/Animal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::animal
 {
@@ -13,7 +14,7 @@ namespace faker::animal
  * faker::animal::bear() // "Polar bear"
  * @endcode
  */
-std::string_view bear();
+FAKER_CXX_EXPORT std::string_view bear();
 
 /**
  * @brief Returns a random species of bird.
@@ -24,7 +25,7 @@ std::string_view bear();
  * faker::animal::bird() // "Black-bellied Whistling-Duck"
  * @endcode
  */
-std::string_view bird();
+FAKER_CXX_EXPORT std::string_view bird();
 
 /**
  * @brief Returns a random species of cat.
@@ -35,7 +36,7 @@ std::string_view bird();
  * faker::animal::cat() // "Chartreux"
  * @endcode
  */
-std::string_view cat();
+FAKER_CXX_EXPORT std::string_view cat();
 
 /**
  * @brief Returns a random species of cetacean.
@@ -46,7 +47,7 @@ std::string_view cat();
  * faker::animal::cetacean() // "Blue Whale"
  * @endcode
  */
-std::string_view cetacean();
+FAKER_CXX_EXPORT std::string_view cetacean();
 
 /**
  * @brief Returns a random species of cow.
@@ -57,7 +58,7 @@ std::string_view cetacean();
  * faker::animal::cow() // "American Angus"
  * @endcode
  */
-std::string_view cow();
+FAKER_CXX_EXPORT std::string_view cow();
 
 /**
  * @brief Returns a random species of crocodilia.
@@ -68,7 +69,7 @@ std::string_view cow();
  * faker::animal::crocodile() // "Dwarf Crocodile"
  * @endcode
  */
-std::string_view crocodile();
+FAKER_CXX_EXPORT std::string_view crocodile();
 
 /**
  * @brief Returns a random species of dog.
@@ -79,7 +80,7 @@ std::string_view crocodile();
  * faker::animal::dog() // "Shiba Inu"
  * @endcode
  */
-std::string_view dog();
+FAKER_CXX_EXPORT std::string_view dog();
 
 /**
  * @brief Returns a random species of fish.
@@ -90,7 +91,7 @@ std::string_view dog();
  * faker::animal::fish() // "Silver carp"
  * @endcode
  */
-std::string_view fish();
+FAKER_CXX_EXPORT std::string_view fish();
 
 /**
  * @brief Returns a random species of horse.
@@ -101,7 +102,7 @@ std::string_view fish();
  * faker::animal::horse() // "Fjord Horse"
  * @endcode
  */
-std::string_view horse();
+FAKER_CXX_EXPORT std::string_view horse();
 
 /**
  * @brief Returns a random species of insect.
@@ -112,7 +113,7 @@ std::string_view horse();
  * faker::animal::insect() // "Bee"
  * @endcode
  */
-std::string_view insect();
+FAKER_CXX_EXPORT std::string_view insect();
 
 /**
  * @brief Returns a random species of lion.
@@ -123,7 +124,7 @@ std::string_view insect();
  * faker::animal::lion() // "West African Lion"
  * @endcode
  */
-std::string_view lion();
+FAKER_CXX_EXPORT std::string_view lion();
 
 /**
  * @brief Returns a random species of rabbit.
@@ -134,7 +135,7 @@ std::string_view lion();
  * faker::animal::rabbit() // "Californian"
  * @endcode
  */
-std::string_view rabbit();
+FAKER_CXX_EXPORT std::string_view rabbit();
 
 /**
  * @brief Returns a random species of rodent.
@@ -145,7 +146,7 @@ std::string_view rabbit();
  * faker::animal::rodent() // "Chinchilla"
  * @endcode
  */
-std::string_view rodent();
+FAKER_CXX_EXPORT std::string_view rodent();
 
 /**
  * @brief Returns a random species of snake.
@@ -156,7 +157,7 @@ std::string_view rodent();
  * faker::animal::snake() // "Boa constrictor"
  * @endcode
  */
-std::string_view snake();
+FAKER_CXX_EXPORT std::string_view snake();
 
 /**
  * @brief Returns a random type of animal.
@@ -167,5 +168,5 @@ std::string_view snake();
  * faker::animal::type() // "dog"
  * @endcode
  */
-std::string_view type();
+FAKER_CXX_EXPORT std::string_view type();
 }

--- a/include/faker-cxx/Book.h
+++ b/include/faker-cxx/Book.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::book
 {
@@ -13,7 +14,7 @@ namespace faker::book
  * faker::book::title() // "Romeo and Juliet"
  * @endcode
  */
-std::string_view title();
+FAKER_CXX_EXPORT std::string_view title();
 
 /**
  * @brief Returns a random book genre.
@@ -24,7 +25,7 @@ std::string_view title();
  * faker::book::genre() // "Fantasy"
  * @endcode
  */
-std::string_view genre();
+FAKER_CXX_EXPORT std::string_view genre();
 
 /**
  * @brief Returns a random book author.
@@ -35,7 +36,7 @@ std::string_view genre();
  * faker::book::author() // "William Shakespeare"
  * @endcode
  */
-std::string_view author();
+FAKER_CXX_EXPORT std::string_view author();
 
 /**
  * @brief Returns a random book publisher.
@@ -46,7 +47,7 @@ std::string_view author();
  * faker::book::publisher() // "Addison-Wesley"
  * @endcode
  */
-std::string_view publisher();
+FAKER_CXX_EXPORT std::string_view publisher();
 
 /**
  * @brief Returns format of book
@@ -57,7 +58,7 @@ std::string_view publisher();
  * faker::book::format() // "Paperback"
  * @endcode
  */
-std::string_view format();
+FAKER_CXX_EXPORT std::string_view format();
 
 /**
  * @brief returns a random book series
@@ -68,5 +69,5 @@ std::string_view format();
  * faker::book::series() // "Harry Potter"
  * @endcode
  */
-std::string_view series();
+FAKER_CXX_EXPORT std::string_view series();
 }

--- a/include/faker-cxx/Color.h
+++ b/include/faker-cxx/Color.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "types/Hex.h"
+#include "faker-cxx/Export.h"
 
 namespace faker::color
 {
@@ -15,7 +16,7 @@ namespace faker::color
  * faker::color::name() // "Blue"
  * @endcode
  */
-std::string_view name();
+FAKER_CXX_EXPORT std::string_view name();
 
 /**
  * @brief Returns an RGB color.
@@ -29,7 +30,7 @@ std::string_view name();
  * faker::color::rgb(true) // "rgba(220, 28, 79, 0.50)"
  * @endcode
  */
-std::string rgb(bool includeAlpha = false);
+FAKER_CXX_EXPORT std::string rgb(bool includeAlpha = false);
 
 /**
  * @brief Returns a hex color.
@@ -45,7 +46,7 @@ std::string rgb(bool includeAlpha = false);
  * faker::color::hex(HexCasing::Upper, HexPrefix::ZeroX, true) // "0xE3F3801A"
  * @endcode
  */
-std::string hex(HexCasing casing = HexCasing::Lower, HexPrefix prefix = HexPrefix::Hash, bool includeAlpha = false);
+FAKER_CXX_EXPORT std::string hex(HexCasing casing = HexCasing::Lower, HexPrefix prefix = HexPrefix::Hash, bool includeAlpha = false);
 
 /**
  * @brief Returns an HSL color.
@@ -57,7 +58,7 @@ std::string hex(HexCasing casing = HexCasing::Lower, HexPrefix prefix = HexPrefi
  * faker::color::hsl(true) // "hsla(0, 0, 100, 0.50)"
  * @endcode
  */
-std::string hsl(bool includeAlpha = false);
+FAKER_CXX_EXPORT std::string hsl(bool includeAlpha = false);
 
 /**
  * @brief Returns an LCH color.
@@ -69,7 +70,7 @@ std::string hsl(bool includeAlpha = false);
  * faker::color::lch(true) // "lcha(0, 0, 100, 0.50)"
  * @endcode
  */
-std::string lch(bool includeAlpha = false);
+FAKER_CXX_EXPORT std::string lch(bool includeAlpha = false);
 
 /**
  * @brief Return a CMYK color
@@ -79,7 +80,7 @@ std::string lch(bool includeAlpha = false);
  * faker::color::cmyk() // "cmyk(0.72, 0.88, 0.00, 0.06)"
  * @endcode
  */
-std::string cmyk();
+FAKER_CXX_EXPORT std::string cmyk();
 
 /**
  * @brief Return a LAB color
@@ -89,7 +90,7 @@ std::string cmyk();
  * faker::color::lab() // "lab(98.74, 2.18, -2.35)"
  * @endcode
  */
-std::string lab();
+FAKER_CXX_EXPORT std::string lab();
 
 /**
  * @brief Return a HSB color
@@ -99,7 +100,7 @@ std::string lab();
  * faker::color::hsb() // "hsb(37, 82, 50)"
  * @endcode
  */
-std::string hsb();
+FAKER_CXX_EXPORT std::string hsb();
 
 /**
  * @brief Return a HSV color
@@ -109,7 +110,7 @@ std::string hsb();
  * faker::color::hsv() // "hsv(21, 67, 39)"
  * @endcode
  */
-std::string hsv();
+FAKER_CXX_EXPORT std::string hsv();
 
 /**
  * @brief Return a YUV color
@@ -119,5 +120,5 @@ std::string hsv();
  * faker::color::yuv() // "yuv(42, 234, 109)"
  * @endcode
  */
-std::string yuv();
+FAKER_CXX_EXPORT std::string yuv();
 }

--- a/include/faker-cxx/Commerce.h
+++ b/include/faker-cxx/Commerce.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::commerce
 {
@@ -13,7 +14,7 @@ namespace faker::commerce
  * faker::commerce::department() // "Books"
  * @endcode
  */
-std::string_view department();
+FAKER_CXX_EXPORT std::string_view department();
 
 /**
  * @brief Generates a random sku by default only with digits.
@@ -25,7 +26,7 @@ std::string_view department();
  * faker::commerce::sku(8) // "10512056"
  * @endcode
  */
-std::string sku(unsigned length = 4);
+FAKER_CXX_EXPORT std::string sku(unsigned length = 4);
 
 /**
  * @brief Returns a random product adjective.
@@ -36,7 +37,7 @@ std::string sku(unsigned length = 4);
  * faker::commerce::productAdjective() // "Handcrafted"
  * @endcode
  */
-std::string_view productAdjective();
+FAKER_CXX_EXPORT std::string_view productAdjective();
 
 /**
  * @brief Returns a random product material.
@@ -47,7 +48,7 @@ std::string_view productAdjective();
  * faker::commerce::productMaterial() // "Wooden"
  * @endcode
  */
-std::string_view productMaterial();
+FAKER_CXX_EXPORT std::string_view productMaterial();
 
 /**
  * @brief Returns a random product short name.
@@ -58,7 +59,7 @@ std::string_view productMaterial();
  * faker::commerce::productName() // "Computer"
  * @endcode
  */
-std::string_view productName();
+FAKER_CXX_EXPORT std::string_view productName();
 
 /**
  * @brief Returns a random product full name.
@@ -69,7 +70,7 @@ std::string_view productName();
  * faker::commerce::productFullName() // "Incredible Soft Gloves"
  * @endcode
  */
-std::string productFullName();
+FAKER_CXX_EXPORT std::string productFullName();
 
 /**
  * @brief Returns a random valid ean13 code.
@@ -80,7 +81,7 @@ std::string productFullName();
  * faker::commerce::EAN13() // "1234567890128"
  * @endcode
  */
-std::string EAN13();
+FAKER_CXX_EXPORT std::string EAN13();
 
 /**
  * @brief Returns a random valid ean8 code.
@@ -91,7 +92,7 @@ std::string EAN13();
  * faker::commerce::EAN8() // "90311017"
  * @endcode
  */
-std::string EAN8();
+FAKER_CXX_EXPORT std::string EAN8();
 
 /**
  * @brief Returns a random valid isbn13 code.
@@ -102,7 +103,7 @@ std::string EAN8();
  * faker::commerce::ISBN13() // "9781234567897"
  * @endcode
  */
-std::string ISBN13();
+FAKER_CXX_EXPORT std::string ISBN13();
 
 /**
  * @brief Returns a random valid ISBN10 code.
@@ -113,7 +114,7 @@ std::string ISBN13();
  * faker::commerce::ISBN10() // "0200716018"
  * @endcode
  */
-std::string ISBN10();
+FAKER_CXX_EXPORT std::string ISBN10();
 
 /**
  * @brief Returns a random payment type.
@@ -124,7 +125,7 @@ std::string ISBN10();
  * faker::commerce::paymentType() // "Credit Card"
  * @endcode
  */
-std::string_view paymentType();
+FAKER_CXX_EXPORT std::string_view paymentType();
 
 /**
  * @brief Returns a random payment provider.
@@ -135,7 +136,7 @@ std::string_view paymentType();
  * faker::commerce::paymentProvider() // "Paypal"
  * @endcode
  */
-std::string_view paymentProvider();
+FAKER_CXX_EXPORT std::string_view paymentProvider();
 
 /**
  * @brief Returns a random product description.
@@ -146,7 +147,7 @@ std::string_view paymentProvider();
  * faker::commerce::productDescription() // "Elevate your lifestyle with premium quality product."
  * @endcode
  */
-std::string_view productDescription();
+FAKER_CXX_EXPORT std::string_view productDescription();
 
 /**
  * @brief Returns a random product category.
@@ -157,7 +158,7 @@ std::string_view productDescription();
  * faker::commerce::productCategory() // "Electronics"
  * @endcode
  */
-std::string_view productCategory();
+FAKER_CXX_EXPORT std::string_view productCategory();
 
 /**
  * @brief Returns a random product review.
@@ -168,7 +169,7 @@ std::string_view productCategory();
  * faker::commerce::productReview() //  "Unfortunately, it broke shortly after I started using it."
  * @endcode
  */
-std::string_view productReview();
+FAKER_CXX_EXPORT std::string_view productReview();
 
 /**
  * @brief Returns a random discount type.
@@ -179,7 +180,7 @@ std::string_view productReview();
  * faker::commerce::discountType() // "percentage"
  * @endcode
  */
-std::string_view discountType();
+FAKER_CXX_EXPORT std::string_view discountType();
 
 /**
  * @brief Returns a random order status.
@@ -190,7 +191,7 @@ std::string_view discountType();
  * faker::commerce::orderStatus() // "shipped"
  * @endcode
  */
-std::string_view orderStatus();
+FAKER_CXX_EXPORT std::string_view orderStatus();
 
 /**
  * @brief Returns a random shipping carrier.
@@ -201,5 +202,5 @@ std::string_view orderStatus();
  * faker::commerce::shippingMethod() // "FedEx"
  * @endcode
  */
-std::string_view shippingCarrier();
+FAKER_CXX_EXPORT std::string_view shippingCarrier();
 }

--- a/include/faker-cxx/Company.h
+++ b/include/faker-cxx/Company.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::company
 {
@@ -13,7 +14,7 @@ namespace faker::company
  * faker::company::name() // "Adams Inc"
  * @endcode
  */
-std::string name();
+FAKER_CXX_EXPORT std::string name();
 
 /**
  * @brief Returns a random company type.
@@ -24,7 +25,7 @@ std::string name();
  * faker::company::type() // "Nonprofit"
  * @endcode
  */
-std::string_view type();
+FAKER_CXX_EXPORT std::string_view type();
 
 /**
  * @brief Returns a random company industry.
@@ -35,7 +36,7 @@ std::string_view type();
  * faker::company::industry() // "Biotechnology"
  * @endcode
  */
-std::string_view industry();
+FAKER_CXX_EXPORT std::string_view industry();
 
 /**
  * @brief Returns a random buzz phrase.
@@ -46,7 +47,7 @@ std::string_view industry();
  * faker::company::buzzPhrase() // "cultivate synergistic e-market"
  * @endcode
  */
-std::string buzzPhrase();
+FAKER_CXX_EXPORT std::string buzzPhrase();
 
 /**
  * @brief Returns a random buzz adjective.
@@ -57,7 +58,7 @@ std::string buzzPhrase();
  * faker::company::buzzAdjective() // "one-to-one"
  * @endcode
  */
-std::string_view buzzAdjective();
+FAKER_CXX_EXPORT std::string_view buzzAdjective();
 
 /**
  * @brief Returns a random buzz noun.
@@ -68,7 +69,7 @@ std::string_view buzzAdjective();
  * faker::company::buzzNoun() // "paradigms"
  * @endcode
  */
-std::string_view buzzNoun();
+FAKER_CXX_EXPORT std::string_view buzzNoun();
 
 /**
  * @brief Returns a random buzz verb.
@@ -79,7 +80,7 @@ std::string_view buzzNoun();
  * faker::company::buzzVerb() // "empower"
  * @endcode
  */
-std::string_view buzzVerb();
+FAKER_CXX_EXPORT std::string_view buzzVerb();
 
 /**
  * @brief Returns a random catch phrase.
@@ -90,7 +91,7 @@ std::string_view buzzVerb();
  * faker::company::catchPhrase() // "Upgradable systematic flexibility"
  * @endcode
  */
-std::string catchPhrase();
+FAKER_CXX_EXPORT std::string catchPhrase();
 
 /**
  * @brief Returns a random catch phrase adjective.
@@ -101,7 +102,7 @@ std::string catchPhrase();
  * faker::company::catchPhraseAdjective() // "Multi-tiered"
  * @endcode
  */
-std::string_view catchPhraseAdjective();
+FAKER_CXX_EXPORT std::string_view catchPhraseAdjective();
 
 /**
  * @brief Returns a random catch phrase descriptor.
@@ -112,7 +113,7 @@ std::string_view catchPhraseAdjective();
  * faker::company::catchPhraseDescriptor() // "composite"
  * @endcode
  */
-std::string_view catchPhraseDescriptor();
+FAKER_CXX_EXPORT std::string_view catchPhraseDescriptor();
 
 /**
  * @brief Returns a random catch phrase noun.
@@ -123,5 +124,5 @@ std::string_view catchPhraseDescriptor();
  * faker::company::catchPhraseNoun() // "leverage"
  * @endcode
  */
-std::string_view catchPhraseNoun();
+FAKER_CXX_EXPORT std::string_view catchPhraseNoun();
 }

--- a/include/faker-cxx/Computer.h
+++ b/include/faker-cxx/Computer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::computer
 {
@@ -13,7 +14,7 @@ namespace faker::computer
  * faker::computer::type() // Laptop
  * @endcode
  */
-std::string_view type();
+FAKER_CXX_EXPORT std::string_view type();
 
 /**
  * @brief Returns a random computer manufacture name.
@@ -24,7 +25,7 @@ std::string_view type();
  * faker::computer::manufacture() // HP
  * @endcode
  */
-std::string_view manufacture();
+FAKER_CXX_EXPORT std::string_view manufacture();
 
 /**
  * @brief Returns a random computer model.
@@ -35,7 +36,7 @@ std::string_view manufacture();
  * faker::computer::model() // MacBook Air
  * @endcode
  */
-std::string_view model();
+FAKER_CXX_EXPORT std::string_view model();
 
 /**
  * @brief Returns a random CPU manufacture name.
@@ -46,7 +47,7 @@ std::string_view model();
  * faker::computer::cpuManufacture() // Intel
  * @endcode
  */
-std::string_view cpuManufacture();
+FAKER_CXX_EXPORT std::string_view cpuManufacture();
 
 /**
  * @brief Returns a random CPU type.
@@ -57,7 +58,7 @@ std::string_view cpuManufacture();
  * faker::computer::cpuType() // x86
  * @endcode
  */
-std::string_view cpuType();
+FAKER_CXX_EXPORT std::string_view cpuType();
 
 /**
  * @brief Returns a random CPU model.
@@ -68,7 +69,7 @@ std::string_view cpuType();
  * faker::computer::cpuModel() // Core i9-11900k
  * @endcode
  */
-std::string_view cpuModel();
+FAKER_CXX_EXPORT std::string_view cpuModel();
 
 /**
  * @brief Returns a random GPU manufacture name.
@@ -79,7 +80,7 @@ std::string_view cpuModel();
  * faker::computer::gpuManufacture() // NVIDIA
  * @endcode
  */
-std::string_view gpuManufacture();
+FAKER_CXX_EXPORT std::string_view gpuManufacture();
 
 /**
  * @brief Returns a random GPU type.
@@ -90,7 +91,7 @@ std::string_view gpuManufacture();
  * faker::computer::gpuType() // Integrated
  * @endcode
  */
-std::string_view gpuType();
+FAKER_CXX_EXPORT std::string_view gpuType();
 
 /**
  * @brief Returns a random GPU model.
@@ -101,6 +102,6 @@ std::string_view gpuType();
  * faker::computer::gpuModel() // NVIDIA GeForce RTX 3080
  * @endcode
  */
-std::string_view gpuModel();
+FAKER_CXX_EXPORT std::string_view gpuModel();
 
 }

--- a/include/faker-cxx/Crypto.h
+++ b/include/faker-cxx/Crypto.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include "faker-cxx/Export.h"
 
 namespace faker::crypto
 {
@@ -15,7 +16,7 @@ namespace faker::crypto
  * faker::crypto::sha256()    // Random hash of random
  * @endcode
  */
-std::string sha256(std::optional<std::string> = std::nullopt);
+FAKER_CXX_EXPORT std::string sha256(std::optional<std::string> = std::nullopt);
 
 /**
  * @brief Returns a random MD5 hash or hash of provided data.
@@ -27,5 +28,5 @@ std::string sha256(std::optional<std::string> = std::nullopt);
  * faker::crypto::md5()    // Random hash of random word
  * @endcode
  */
-std::string md5(std::optional<std::string> = std::nullopt);
+FAKER_CXX_EXPORT std::string md5(std::optional<std::string> = std::nullopt);
 }

--- a/include/faker-cxx/Database.h
+++ b/include/faker-cxx/Database.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::database
 {
@@ -13,7 +14,7 @@ namespace faker::database
      * faker::database::columnName() // "created_at"
      * @endcode
      */
-    std::string_view columnName();
+    FAKER_CXX_EXPORT std::string_view columnName();
 
     /**
      * @brief Returns a random database column type.
@@ -24,7 +25,7 @@ namespace faker::database
      * faker::database::columnType() // "timestamp"
      * @endcode
      */
-    std::string_view columnType();
+    FAKER_CXX_EXPORT std::string_view columnType();
 
     /**
      * @brief Returns a random database collation.
@@ -35,7 +36,7 @@ namespace faker::database
      * faker::database::collation() // "utf8_unicode_ci"
      * @endcode
      */
-    std::string_view collation();
+    FAKER_CXX_EXPORT std::string_view collation();
 
     /**
      * @brief Returns a random database engine.
@@ -46,7 +47,7 @@ namespace faker::database
      * faker::database::engine() // "ARCHIVE"
      * @endcode
      */
-    std::string_view engine();
+    FAKER_CXX_EXPORT std::string_view engine();
 
     /**
      * @brief Returns a MongoDB Object Id.
@@ -57,5 +58,5 @@ namespace faker::database
      * faker::database::mongoDbObjectId() // "e175cac316a79afdd0ad3afb"
      * @endcode
      */
-    std::string mongoDbObjectId();
+    FAKER_CXX_EXPORT std::string mongoDbObjectId();
 }

--- a/include/faker-cxx/Datatype.h
+++ b/include/faker-cxx/Datatype.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "faker-cxx/Export.h"
+
 namespace faker::datatype
 {
 /**
@@ -11,7 +13,7 @@ namespace faker::datatype
  * faker::datatype::boolean() // "false"
  * @endcode
  */
-bool boolean();
+FAKER_CXX_EXPORT bool boolean();
 
 /**
  * @brief Returns a random boolean.
@@ -31,5 +33,5 @@ bool boolean();
  * faker::datatype::boolean(0.1) // "false"
  * @endcode
  */
-bool boolean(double probability);
+FAKER_CXX_EXPORT bool boolean(double probability);
 }

--- a/include/faker-cxx/Date.h
+++ b/include/faker-cxx/Date.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::date
 {
@@ -24,7 +25,7 @@ namespace faker::date
      * faker::date::pastDate(5, DateFormat::Timestamp) // "1592321049"
      * @endcode
      */
-    std::string pastDate(int years = 1, DateFormat dateFormat = DateFormat::ISO);
+    FAKER_CXX_EXPORT std::string pastDate(int years = 1, DateFormat dateFormat = DateFormat::ISO);
 
     /**
      * @brief Generates a random date in the future.
@@ -40,7 +41,7 @@ namespace faker::date
      * faker::date::futureDate(5, DateFormat::Timestamp) // "1718229989"
      * @endcode
      */
-    std::string futureDate(int years = 1, DateFormat dateFormat = DateFormat::ISO);
+    FAKER_CXX_EXPORT std::string futureDate(int years = 1, DateFormat dateFormat = DateFormat::ISO);
 
     /**
      * @brief Generates a random date in the recent past.
@@ -56,7 +57,7 @@ namespace faker::date
      * faker::date::recentDate(10, DateFormat::Timestamp) // "1718229989"
      * @endcode
      */
-    std::string recentDate(int days = 3, DateFormat dateFormat = DateFormat::ISO);
+    FAKER_CXX_EXPORT std::string recentDate(int days = 3, DateFormat dateFormat = DateFormat::ISO);
 
     /**
      * @brief Generates a random date in the soon future.
@@ -72,7 +73,7 @@ namespace faker::date
      * faker::date::soonDate(10, DateFormat::Timestamp) // "1718229989"
      * @endcode
      */
-    std::string soonDate(int days = 3, DateFormat dateFormat = DateFormat::ISO);
+    FAKER_CXX_EXPORT std::string soonDate(int days = 3, DateFormat dateFormat = DateFormat::ISO);
 
     /**
      * @brief Generates a random birthdate by age.
@@ -89,7 +90,7 @@ namespace faker::date
      * faker::date::birthdateByAge(20, 30, DateFormat::Timestamp) // "1718229989"
      * @endcode
      */
-    std::string birthdateByAge(int minAge = 18, int maxAge = 80, DateFormat dateFormat = DateFormat::ISO);
+    FAKER_CXX_EXPORT std::string birthdateByAge(int minAge = 18, int maxAge = 80, DateFormat dateFormat = DateFormat::ISO);
 
     /**
      * @brief Generates a random birthdate by year.
@@ -106,7 +107,7 @@ namespace faker::date
      * faker::date::birthdateByYear(1996, 1996, DateFormat::Timestamp) // "1718229989"
      * @endcode
      */
-    std::string birthdateByYear(int minYear = 1920, int maxYear = 2000, DateFormat dateFormat = DateFormat::ISO);
+    FAKER_CXX_EXPORT std::string birthdateByYear(int minYear = 1920, int maxYear = 2000, DateFormat dateFormat = DateFormat::ISO);
 
     /**
      * @brief Returns a name of random day of the week.
@@ -117,7 +118,7 @@ namespace faker::date
      * faker::date::weekdayName() // "Monday"
      * @endcode
      */
-    std::string_view weekdayName();
+    FAKER_CXX_EXPORT std::string_view weekdayName();
 
     /**
      * @brief Returns an abbreviated name of random day of the week.
@@ -128,7 +129,7 @@ namespace faker::date
      * faker::date::weekdayAbbreviatedName() // "Mon"
      * @endcode
      */
-    std::string_view weekdayAbbreviatedName();
+    FAKER_CXX_EXPORT std::string_view weekdayAbbreviatedName();
 
     /**
      * @brief Returns a random name of a month.
@@ -139,7 +140,7 @@ namespace faker::date
      * faker::date::monthName() // "October"
      * @endcode
      */
-    std::string_view monthName();
+    FAKER_CXX_EXPORT std::string_view monthName();
 
     /**
      * @brief Returns an abbreviated name of random month.
@@ -150,7 +151,7 @@ namespace faker::date
      * faker::date::monthAbbreviatedName() // "Feb"
      * @endcode
      */
-    std::string_view monthAbbreviatedName();
+    FAKER_CXX_EXPORT std::string_view monthAbbreviatedName();
 
     /**
      * @brief Returns random year.
@@ -161,7 +162,7 @@ namespace faker::date
      * faker::date::year() // 2000
      * @endcode
      */
-    unsigned year();
+    FAKER_CXX_EXPORT unsigned year();
 
     /**
      * @brief Returns random month.
@@ -172,7 +173,7 @@ namespace faker::date
      * faker::date::month() // 9
      * @endcode
      */
-    unsigned month();
+    FAKER_CXX_EXPORT unsigned month();
 
     /**
      * @brief Returns random hour.
@@ -183,7 +184,7 @@ namespace faker::date
      * faker::date::hour() // 21
      * @endcode
      */
-    unsigned hour();
+    FAKER_CXX_EXPORT unsigned hour();
 
     /**
      * @brief Returns random minute.
@@ -194,7 +195,7 @@ namespace faker::date
      * faker::date::minute() // 40
      * @endcode
      */
-    unsigned minute();
+    FAKER_CXX_EXPORT unsigned minute();
 
     /**
      * @brief Returns random second.
@@ -205,7 +206,7 @@ namespace faker::date
      * faker::date::second() // 40
      * @endcode
      */
-    unsigned second();
+    FAKER_CXX_EXPORT unsigned second();
 
     /**
      * @brief Returns random time string.
@@ -216,7 +217,7 @@ namespace faker::date
      * faker::date::time() // 21:40
      * @endcode
      */
-    std::string time();
+    FAKER_CXX_EXPORT std::string time();
 
     /**
      * @brief Returns random day of month.
@@ -227,7 +228,7 @@ namespace faker::date
      * faker::date::dayOfMonth() // 15
      * @endcode
      */
-    unsigned dayOfMonth();
+    FAKER_CXX_EXPORT unsigned dayOfMonth();
 
     /**
      * @brief Returns random day of week.
@@ -238,7 +239,7 @@ namespace faker::date
      * faker::date::dayOfWeek() // 5
      * @endcode
      */
-    unsigned dayOfWeek();
+    FAKER_CXX_EXPORT unsigned dayOfWeek();
 
     /**
      * @brief Returns random timezone.
@@ -249,5 +250,5 @@ namespace faker::date
      * faker::date::timezoneRandom() // PT
      * @endcode
      */
-    std::string_view timezoneRandom();
+    FAKER_CXX_EXPORT std::string_view timezoneRandom();
 }

--- a/include/faker-cxx/Faker.h
+++ b/include/faker-cxx/Faker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "faker-cxx/Export.h"
 #include "faker-cxx/Airline.h"
 #include "faker-cxx/Animal.h"
 #include "faker-cxx/Book.h"

--- a/include/faker-cxx/Finance.h
+++ b/include/faker-cxx/Finance.h
@@ -4,12 +4,13 @@
 #include <string>
 #include <string_view>
 
+#include "faker-cxx/Export.h"
 #include "types/Country.h"
 #include "types/Precision.h"
 
 namespace faker::finance
 {
-    struct Currency
+    struct FAKER_CXX_EXPORT Currency
     {
         std::string_view name;
         std::string_view code;
@@ -26,7 +27,7 @@ namespace faker::finance
      * faker::finance::currency() // "{"US Dollar","USD","$"}"
      * @endcode
      */
-    Currency currency();
+    FAKER_CXX_EXPORT Currency currency();
 
     /**
      * @brief Returns a random currency name.
@@ -37,7 +38,7 @@ namespace faker::finance
      * faker::finance::currencyName() // "US Dollar"
      * @endcode
      */
-    std::string_view currencyName();
+    FAKER_CXX_EXPORT std::string_view currencyName();
 
     /**
      * @brief Returns a random currency code.
@@ -48,7 +49,7 @@ namespace faker::finance
      * faker::finance::currencyCode() // "USD"
      * @endcode
      */
-    std::string_view currencyCode();
+    FAKER_CXX_EXPORT std::string_view currencyCode();
 
     /**
      * @brief Returns a random currency symbol.
@@ -59,7 +60,7 @@ namespace faker::finance
      * faker::finance::currencySymbol() // "$"
      * @endcode
      */
-    std::string_view currencySymbol();
+    FAKER_CXX_EXPORT std::string_view currencySymbol();
 
     /**
      * @brief Returns a random account type.
@@ -70,7 +71,7 @@ namespace faker::finance
      * faker::finance::accountType() // "Savings"
      * @endcode
      */
-    std::string_view accountType();
+    FAKER_CXX_EXPORT std::string_view accountType();
 
     /**
      * @brief Generates a random amount between the given bounds (inclusive).
@@ -89,7 +90,7 @@ namespace faker::finance
      * faker::finance::amount(5, 10, Precision::TwoDp, "$") // "$5.85"
      * @endcode
      */
-    std::string amount(double min = 0, double max = 1000, Precision precision = Precision::TwoDp,
+    FAKER_CXX_EXPORT std::string amount(double min = 0, double max = 1000, Precision precision = Precision::TwoDp,
                               const std::string& symbol = "");
 
     enum class IbanCountry
@@ -135,7 +136,7 @@ namespace faker::finance
      * faker::finance::iban(IbanCountry::Poland) // "PL61109010140000071219812874"
      * @endcode
      */
-    std::string iban(std::optional<IbanCountry> country = std::nullopt);
+    FAKER_CXX_EXPORT std::string iban(std::optional<IbanCountry> country = std::nullopt);
 
     enum class BicCountry
     {
@@ -163,7 +164,7 @@ namespace faker::finance
      * faker::finance::bic(BicCountry::Poland) // "BREXPLPWMUL"
      * @endcode
      */
-    std::string_view bic(std::optional<BicCountry> country = std::nullopt);
+    FAKER_CXX_EXPORT std::string_view bic(std::optional<BicCountry> country = std::nullopt);
 
     /**
      * Generates a random account number.
@@ -177,7 +178,7 @@ namespace faker::finance
      * faker::finance::accountNumber(26) // "55875455514825927518796290"
      * @endcode
      */
-    std::string accountNumber(unsigned length = 8);
+    FAKER_CXX_EXPORT std::string accountNumber(unsigned length = 8);
 
     /**
      * Generates a random PIN number.
@@ -191,7 +192,7 @@ namespace faker::finance
      * faker::finance::pin(8) // "21378928"
      * @endcode
      */
-    std::string pin(unsigned length = 4);
+    FAKER_CXX_EXPORT std::string pin(unsigned length = 4);
 
     /**
      * Generates a random routing number.
@@ -202,7 +203,7 @@ namespace faker::finance
      * faker::finance::routingNumber() // "522814402"
      * @endcode
      */
-    std::string routingNumber();
+    FAKER_CXX_EXPORT std::string routingNumber();
 
     enum class CreditCardType
     {
@@ -223,7 +224,7 @@ namespace faker::finance
      * faker::finance::creditCardNumber() // "4882664999007"
      * @endcode
      */
-    std::string creditCardNumber(std::optional<CreditCardType> creditCardType = std::nullopt);
+    FAKER_CXX_EXPORT std::string creditCardNumber(std::optional<CreditCardType> creditCardType = std::nullopt);
 
     /**
      * Generates a random credit card CVV.
@@ -234,7 +235,7 @@ namespace faker::finance
      * faker::finance::creditCardCvv() // "506"
      * @endcode
      */
-    std::string creditCardCvv();
+    FAKER_CXX_EXPORT std::string creditCardCvv();
 
     /**
      * Generates a random bitcoin address.
@@ -245,7 +246,7 @@ namespace faker::finance
      * faker::finance::bitcoinAddress() // "3ySdvCkTLVy7gKD4j6JfSaf5d"
      * @endcode
      */
-    std::string bitcoinAddress();
+    FAKER_CXX_EXPORT std::string bitcoinAddress();
 
     /**
      * Generates a random litecoin address.
@@ -256,7 +257,7 @@ namespace faker::finance
      * faker::finance::litecoinAddress() // "LoQaSTGWBRXkWfyxKbNKuPrAWGELzcW"
      * @endcode
      */
-    std::string litecoinAddress();
+    FAKER_CXX_EXPORT std::string litecoinAddress();
 
     /**
      * Generates a random ethereum address.
@@ -267,7 +268,7 @@ namespace faker::finance
      * faker::finance::ethereumAddress() // "0xf03dfeecbafc5147241cc4c4ca20b3c9dfd04c4a"
      * @endcode
      */
-    std::string ethereumAddress();
+    FAKER_CXX_EXPORT std::string ethereumAddress();
 
     /**
      * Generates a random expiration date.
@@ -278,7 +279,7 @@ namespace faker::finance
      * faker::finance::creditCardExpirationDate() // "03/26"
      * @endcode
      */
-    std::string creditCardExpirationDate();
+    FAKER_CXX_EXPORT std::string creditCardExpirationDate();
 
     /**
      * Generates a random credit card type.
@@ -289,6 +290,6 @@ namespace faker::finance
      * faker::finance::creditCardType() // "Visa"
      * @endcode
      */
-    std::string_view creditCardType();
+    FAKER_CXX_EXPORT std::string_view creditCardType();
 
 }

--- a/include/faker-cxx/Food.h
+++ b/include/faker-cxx/Food.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::food
 {
@@ -13,7 +14,7 @@ namespace faker::food
      * faker::food::alcoholicBeverage() // "champain"
      * @endcode
      */
-    std::string_view alcoholicBeverage();
+    FAKER_CXX_EXPORT std::string_view alcoholicBeverage();
 
     /**
      * @brief Returns a random grain measurement.
@@ -24,7 +25,7 @@ namespace faker::food
      * faker::food::grain() // "1 Lt"
      * @endcode
      */
-    std::string_view grain();
+    FAKER_CXX_EXPORT std::string_view grain();
 
     /**
      * @brief Returns a random milk product's name.
@@ -35,7 +36,7 @@ namespace faker::food
      * faker::food::milkProduct() // "mozzarella"
      * @endcode
      */
-    std::string_view milkProduct();
+    FAKER_CXX_EXPORT std::string_view milkProduct();
 
     /**
      * @brief Returns a random fruit's name.
@@ -46,7 +47,7 @@ namespace faker::food
      * faker::food::fruit() // "apple"
      * @endcode
      */
-    std::string_view fruit();
+    FAKER_CXX_EXPORT std::string_view fruit();
 
     /**
      * @brief Returns a random meat's name.
@@ -57,7 +58,7 @@ namespace faker::food
      * faker::food::meat() // "antrikot"
      * @endcode
      */
-    std::string_view meat();
+    FAKER_CXX_EXPORT std::string_view meat();
 
     /**
      * @brief Returns a random seafood's name.
@@ -68,7 +69,7 @@ namespace faker::food
      * faker::food::seafood() // "lobster"
      * @endcode
      */
-    std::string_view seafood();
+    FAKER_CXX_EXPORT std::string_view seafood();
 
     /**
      * @brief Returns a random vegetable's name.
@@ -79,7 +80,7 @@ namespace faker::food
      * faker::food::vegetable() // "watermelon"
      * @endcode
      */
-    std::string_view vegetable();
+    FAKER_CXX_EXPORT std::string_view vegetable();
 
     /**
      * @brief Returns a random oil's name.
@@ -90,7 +91,7 @@ namespace faker::food
      * faker::food::oil() // "olive oil"
      * @endcode
      */
-    std::string_view oil();
+    FAKER_CXX_EXPORT std::string_view oil();
 
     /**
      * @brief Returns a random nut's name.
@@ -101,7 +102,7 @@ namespace faker::food
      * faker::food::nut() // "walnut"
      * @endcode
      */
-    std::string_view nut();
+    FAKER_CXX_EXPORT std::string_view nut();
 
     /**
      * @brief Returns a random seed's name.
@@ -112,7 +113,7 @@ namespace faker::food
      * faker::food::seed() // "mozzarella"
      * @endcode
      */
-    std::string_view seed();
+    FAKER_CXX_EXPORT std::string_view seed();
 
     /**
      * @brief Returns a random sugar product's name.
@@ -123,7 +124,7 @@ namespace faker::food
      * faker::food::sugarProduct() // "honey harmony"
      * @endcode
      */
-    std::string_view sugarProduct();
+    FAKER_CXX_EXPORT std::string_view sugarProduct();
 
     /**
      * @brief Returns a random non-alcoholic beverage's name.
@@ -134,7 +135,7 @@ namespace faker::food
      * faker::food::nonalcoholicBeverage() // "water"
      * @endcode
      */
-    std::string_view nonalcoholicBeverage();
+    FAKER_CXX_EXPORT std::string_view nonalcoholicBeverage();
 
     /**
      * @brief Returns a random dish's name.
@@ -145,7 +146,7 @@ namespace faker::food
      * faker::food::dishName() // "beef wellington"
      * @endcode
      */
-    std::string_view dishName();
+    FAKER_CXX_EXPORT std::string_view dishName();
 
     /**
      * @brief Returns a random food categories' name.
@@ -156,5 +157,5 @@ namespace faker::food
      * faker::food::foodCategory() // "Dairy"
      * @endcode
      */
-    std::string_view foodCategory();
+    FAKER_CXX_EXPORT std::string_view foodCategory();
 }

--- a/include/faker-cxx/Git.h
+++ b/include/faker-cxx/Git.h
@@ -3,11 +3,12 @@
 #include <optional>
 #include <string>
 
+#include "faker-cxx/Export.h"
 #include "faker-cxx/types/Country.h"
 
 namespace faker::git
 {
-struct Author
+struct FAKER_CXX_EXPORT Author
 {
     std::string name;
     std::string email;
@@ -23,7 +24,7 @@ struct Author
  * faker::git::branch() // "capitalize-bus"
  * @endcode
  */
-std::string branch(unsigned maxIssueNum = 100);
+FAKER_CXX_EXPORT std::string branch(unsigned maxIssueNum = 100);
 
 /**
  * @brief Generates a random date in form of string.
@@ -35,7 +36,7 @@ std::string branch(unsigned maxIssueNum = 100);
  * faker::git::commitDate() // "Mon Jan 17 15:05:53 2022 +1100"
  * @endcode
  */
-std::string commitDate(unsigned years = 15);
+FAKER_CXX_EXPORT std::string commitDate(unsigned years = 15);
 
 /**
  * @brief Generates a random commit entry in form of string.
@@ -54,7 +55,7 @@ std::string commitDate(unsigned years = 15);
                             spawn polyp"
  * @endcode
  */
-std::string commitEntry(std::optional<unsigned> dateYears = std::nullopt,
+FAKER_CXX_EXPORT std::string commitEntry(std::optional<unsigned> dateYears = std::nullopt,
                         std::optional<unsigned> shaLength = std::nullopt, Country country = Country::England);
 
 /**
@@ -66,7 +67,7 @@ std::string commitEntry(std::optional<unsigned> dateYears = std::nullopt,
  * faker::git::commitMessage() // "spawn polyp"
  * @endcode
  */
-std::string commitMessage();
+FAKER_CXX_EXPORT std::string commitMessage();
 
 /**
  * @brief Returns a random SHA hash.
@@ -79,5 +80,5 @@ std::string commitMessage();
  * faker::git::commitSha() // "9cbc41bb8ce0438c8de9cb25a1c6ad33441d8aca"
  * @endcode
  */
-std::string commitSha(unsigned length = 40);
+FAKER_CXX_EXPORT std::string commitSha(unsigned length = 40);
 }

--- a/include/faker-cxx/Hacker.h
+++ b/include/faker-cxx/Hacker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::hacker
 {
@@ -13,7 +14,7 @@ namespace faker::hacker
      * faker::hacker::abbreviation() // "TCP"
      * @endcode
      */
-    std::string_view abbreviation();
+    FAKER_CXX_EXPORT std::string_view abbreviation();
 
     /**
      * @brief Returns a random adjective.
@@ -24,7 +25,7 @@ namespace faker::hacker
      * faker::hacker::adjective() // "open-source"
      * @endcode
      */
-    std::string_view adjective();
+    FAKER_CXX_EXPORT std::string_view adjective();
 
     /**
      * @brief Returns a random noun.
@@ -35,7 +36,7 @@ namespace faker::hacker
      * faker::hacker::noun() // "coder"
      * @endcode
      */
-    std::string_view noun();
+    FAKER_CXX_EXPORT std::string_view noun();
 
     /**
      * @brief Returns a random verb.
@@ -46,7 +47,7 @@ namespace faker::hacker
      * faker::hacker::verb() // "run"
      * @endcode
      */
-    std::string_view verb();
+    FAKER_CXX_EXPORT std::string_view verb();
 
     /**
      * @brief Returns a random ingverb.
@@ -57,7 +58,7 @@ namespace faker::hacker
      * faker::hacker::ingverb() // "backing up"
      * @endcode
      */
-    std::string_view ingverb();
+    FAKER_CXX_EXPORT std::string_view ingverb();
 
     /**
      * @brief Returns a random phrase.
@@ -68,5 +69,5 @@ namespace faker::hacker
      * faker::hacker::phrase() // "If we bypass the monitor, we can get to the TCP monitor through the neural EXE monitor!"
      * @endcode
      */
-    std::string phrase();
+    FAKER_CXX_EXPORT std::string phrase();
 }

--- a/include/faker-cxx/Helper.h
+++ b/include/faker-cxx/Helper.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "faker-cxx/Export.h"
 #include "Datatype.h"
 #include "Number.h"
 
@@ -224,7 +225,7 @@ T weightedArrayElement(const std::vector<WeightedElement<T>>& data)
  * faker::helper::shuffleString("hello") // "eollh"
  * @endcode
  */
-std::string shuffleString(std::string data);
+FAKER_CXX_EXPORT std::string shuffleString(std::string data);
 
 /**
  * @brief Returns a random key from given object.
@@ -330,7 +331,7 @@ std::vector<T> toVector(const std::array<T, N>& arr)
  * faker::helper::replaceSymbolWithNumber("Your pin is: !####") // "29841"
  * @endcode
  */
-std::string replaceSymbolWithNumber(const std::string& str, const char& symbol = '#');
+FAKER_CXX_EXPORT std::string replaceSymbolWithNumber(const std::string& str, const char& symbol = '#');
 
 /**
  * @brief Returns credit card schema with replaced symbols and patterns in a credit card  including Luhn checksum
@@ -347,7 +348,7 @@ std::string replaceSymbolWithNumber(const std::string& str, const char& symbol =
  * faker::helper::replaceCreditCardSymbols("1234-[4-9]-##!!-L") // "1234-9-5298-2"
  * @endcode
  */
-std::string replaceCreditCardSymbols(const std::string& inputString = "6453-####-####-####-###L", char symbol = '#');
+FAKER_CXX_EXPORT std::string replaceCreditCardSymbols(const std::string& inputString = "6453-####-####-####-###L", char symbol = '#');
 
 /**
  * @brief Returns the replaced regex-like expression in the string with matching values.
@@ -369,5 +370,5 @@ std::string replaceCreditCardSymbols(const std::string& inputString = "6453-####
  * faker::helper::regexpStyleStringParse("#{3}test[1-5]") // "###test3"
  * @endcode
  */
-std::string regexpStyleStringParse(const std::string& input);
+FAKER_CXX_EXPORT std::string regexpStyleStringParse(const std::string& input);
 }

--- a/include/faker-cxx/Image.h
+++ b/include/faker-cxx/Image.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::image
 {
@@ -36,7 +37,7 @@ namespace faker::image
      * faker::image::imageUrl(800, 600, ImageCategory::Animals) // "https://loremflickr.com/800/600/animals"
      * @endcode
      */
-    std::string imageUrl(unsigned width = 640, unsigned height = 480,
+    FAKER_CXX_EXPORT std::string imageUrl(unsigned width = 640, unsigned height = 480,
                                 std::optional<ImageCategory> category = std::nullopt);
 
     /**
@@ -48,7 +49,7 @@ namespace faker::image
      * faker::image::githubAvatarUrl() // "https://avatars.githubusercontent.com/u/9716558"
      * @endcode
      */
-    std::string githubAvatarUrl();
+    FAKER_CXX_EXPORT std::string githubAvatarUrl();
 
     /**
      * @brief Generates a random image dimensions.
@@ -59,7 +60,7 @@ namespace faker::image
      * faker::image::dimensions() // "1920x1080"
      * @endcode
      */
-    std::string dimensions();
+    FAKER_CXX_EXPORT std::string dimensions();
 
     /**
      * @brief Generates a random type of image.
@@ -69,5 +70,5 @@ namespace faker::image
      * @code
      * faker::image::type() // "png"
      */
-    std::string_view type();
+    FAKER_CXX_EXPORT std::string_view type();
 }

--- a/include/faker-cxx/Internet.h
+++ b/include/faker-cxx/Internet.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 
+#include "faker-cxx/Export.h"
 #include "types/Country.h"
 
 namespace faker::internet
@@ -31,7 +32,7 @@ enum class IPv4Class
     C
 };
 
-struct PasswordOptions
+struct FAKER_CXX_EXPORT PasswordOptions
 {
     bool upperLetters = true;
     bool lowerLetters = true;
@@ -54,7 +55,7 @@ struct PasswordOptions
      * faker::internet::username("Andrew", "Cieslar") // "Andrew.Cieslar"
      * @endcode
      */
-    std::string username(std::optional<std::string> firstName = std::nullopt,
+    FAKER_CXX_EXPORT std::string username(std::optional<std::string> firstName = std::nullopt,
                                 std::optional<std::string> lastName = std::nullopt, Country country = Country::Usa);
 
     /**
@@ -74,7 +75,7 @@ struct PasswordOptions
      * faker::internet::email(std::nullopt, std::nullopt, "example.com") // "Wright.Edna1973@code.com"
      * @endcode
      */
-    std::string email(std::optional<std::string> firstName = std::nullopt,
+    FAKER_CXX_EXPORT std::string email(std::optional<std::string> firstName = std::nullopt,
                              std::optional<std::string> lastName = std::nullopt,
                              std::optional<std::string> emailHost = std::nullopt);
 
@@ -90,7 +91,7 @@ struct PasswordOptions
      * faker::internet::exampleEmail() // "Jimenez.Clyde@example.com"
      * @endcode
      */
-    std::string exampleEmail(std::optional<std::string> firstName = std::nullopt,
+    FAKER_CXX_EXPORT std::string exampleEmail(std::optional<std::string> firstName = std::nullopt,
                                     std::optional<std::string> lastName = std::nullopt);
 
     /**
@@ -106,7 +107,7 @@ struct PasswordOptions
      * faker::internet::password(25) // "xv8vDu*wM!Rg0$zd0kH%8p!WY"
      * @endcode
      */
-    std::string password(int length = 15, const PasswordOptions& options = {});
+    FAKER_CXX_EXPORT std::string password(int length = 15, const PasswordOptions& options = {});
 
     enum class EmojiType
     {
@@ -134,7 +135,7 @@ struct PasswordOptions
      * faker::internet::emoji(EmojiType::Food) // "🍕"
      * @endcode
      */
-    std::string_view emoji(std::optional<EmojiType> type = std::nullopt);
+    FAKER_CXX_EXPORT std::string_view emoji(std::optional<EmojiType> type = std::nullopt);
 
     /**
      * @brief Verify that a given emoji is valid.
@@ -147,7 +148,7 @@ struct PasswordOptions
      * faker::internet::checkIfEmojiIsValid("👑") // true
      * @endcode
      */
-    bool checkIfEmojiIsValid(const std::string& emojiToCheck);
+    FAKER_CXX_EXPORT bool checkIfEmojiIsValid(const std::string& emojiToCheck);
 
     /**
      * @brief Returns a random web protocol. Either `http` or `https`.
@@ -158,7 +159,7 @@ struct PasswordOptions
      * faker::internet::protocol() // "https"
      * @endcode
      */
-    std::string_view protocol();
+    FAKER_CXX_EXPORT std::string_view protocol();
 
     /**
      * @brief Generates a random http method name.
@@ -169,7 +170,7 @@ struct PasswordOptions
      * faker::internet::httpMethod() // "POST"
      * @endcode
      */
-    std::string_view httpMethod();
+    FAKER_CXX_EXPORT std::string_view httpMethod();
 
     /**
      * @brief Returns a random http status code.
@@ -183,7 +184,7 @@ struct PasswordOptions
      * faker::internet::httpStatusCode(HttpStatusCodeType::success) // 201
      * @endcode
      */
-    unsigned httpStatusCode(std::optional<HttpResponseType> responseType = std::nullopt);
+    FAKER_CXX_EXPORT unsigned httpStatusCode(std::optional<HttpResponseType> responseType = std::nullopt);
 
     /**
      * @brief Generates a random http request header.
@@ -194,7 +195,7 @@ struct PasswordOptions
      * faker::internet::httpRequestHeader() // "Authorization"
      * @endcode
      */
-    std::string_view httpRequestHeader();
+    FAKER_CXX_EXPORT std::string_view httpRequestHeader();
 
     /**
      * @brief Generates a random http response header.
@@ -205,7 +206,7 @@ struct PasswordOptions
      * faker::internet::httpResponseHeader() // "Location"
      * @endcode
      */
-    std::string_view httpResponseHeader();
+    FAKER_CXX_EXPORT std::string_view httpResponseHeader();
 
     /**
      * @brief Generates a random http media type.
@@ -216,7 +217,7 @@ struct PasswordOptions
      * faker::internet::httpMediaType() // "application/json"
      * @endcode
      */
-    std::string_view httpMediaType();
+    FAKER_CXX_EXPORT std::string_view httpMediaType();
 
     /**
      * @brief Returns a string containing randomized ipv4 address of the given class.
@@ -230,7 +231,7 @@ struct PasswordOptions
      * faker::internet::ipv4(IPv4Class::classA) // "10.0.0.1"
      * @endcode
      */
-    std::string ipv4(const IPv4Class& ipv4class = IPv4Class::C);
+    FAKER_CXX_EXPORT std::string ipv4(const IPv4Class& ipv4class = IPv4Class::C);
 
     /**
      * @brief Returns a string containing randomized ipv4 address based on given base address and mask.
@@ -249,7 +250,7 @@ struct PasswordOptions
      * faker::internet::ipv4({255.255.128.0}, {129.168.255.0}) // "192.168.128.10"
      * @endcode
      */
-    std::string ipv4(const std::array<unsigned int, 4>& baseIpv4Address,
+    FAKER_CXX_EXPORT std::string ipv4(const std::array<unsigned int, 4>& baseIpv4Address,
                             const std::array<unsigned int, 4>& generationMask);
 
     /**
@@ -261,7 +262,7 @@ struct PasswordOptions
      * faker::internet::ipv6() // "269f:1230:73e3:318d:842b:daab:326d:897b"
      * @endcode
      */
-    std::string ipv6();
+    FAKER_CXX_EXPORT std::string ipv6();
 
     /**
      * @brief Returns a generated random mac address.
@@ -274,7 +275,7 @@ struct PasswordOptions
      * faker::internet::mac() // "2d:10:34:2f:ac:ac"
      * @endcode
      */
-    std::string mac(const std::string& sep = ":");
+    FAKER_CXX_EXPORT std::string mac(const std::string& sep = ":");
 
     /**
      * @brief Generates a random port.
@@ -285,7 +286,7 @@ struct PasswordOptions
      * faker::internet::port() // 5432
      * @endcode
      */
-    unsigned port();
+    FAKER_CXX_EXPORT unsigned port();
 
     /**
      * @brief Generates a random url.
@@ -298,7 +299,7 @@ struct PasswordOptions
      * faker::internet::url() // "https://slow-timer.info"
      * @endcode
      */
-    std::string url(const WebProtocol& webProtocol = WebProtocol::Https);
+    FAKER_CXX_EXPORT std::string url(const WebProtocol& webProtocol = WebProtocol::Https);
 
     /**
      * @brief Generates a random domain name.
@@ -309,7 +310,7 @@ struct PasswordOptions
      * faker::internet::domainName() // "slow-timer.info"
      * @endcode
      */
-    std::string domainName();
+    FAKER_CXX_EXPORT std::string domainName();
 
     /**
      * @brief Generates a random domain word.
@@ -320,7 +321,7 @@ struct PasswordOptions
      * faker::internet::domainWord() // "close-reality"
      * @endcode
      */
-    std::string domainWord();
+    FAKER_CXX_EXPORT std::string domainWord();
 
     /**
      * @brief Generates a random domain suffix.
@@ -331,7 +332,7 @@ struct PasswordOptions
      * faker::internet::domainSuffix() // "com"
      * @endcode
      */
-    std::string_view domainSuffix();
+    FAKER_CXX_EXPORT std::string_view domainSuffix();
 
     /**
      * @brief Generates a random username.
@@ -344,5 +345,5 @@ struct PasswordOptions
      * faker::internet::anonymousUsername() // "profusebrother", "richad", "powerfuldifferential"
      * @endcode
      */
-    std::string anonymousUsername(unsigned maxLength);
+    FAKER_CXX_EXPORT std::string anonymousUsername(unsigned maxLength);
 }

--- a/include/faker-cxx/Location.h
+++ b/include/faker-cxx/Location.h
@@ -2,6 +2,7 @@
 
 #include <string_view>
 
+#include "faker-cxx/Export.h"
 #include "types/Precision.h"
 
 namespace faker::location
@@ -34,7 +35,7 @@ enum class AddressCountry
  * faker::location::country() // "Poland"
  * @endcode
  */
-std::string_view country();
+FAKER_CXX_EXPORT std::string_view country();
 
 /**
  * @brief Returns a random country code.
@@ -45,7 +46,7 @@ std::string_view country();
  * faker::location::countryCode() // "PL"
  * @endcode
  */
-std::string_view countryCode();
+FAKER_CXX_EXPORT std::string_view countryCode();
 
 /**
  * @brief Returns a random state for a given country.
@@ -58,7 +59,7 @@ std::string_view countryCode();
  * faker::location::state() // "Arizona"
  * @endcode
  */
-std::string_view state(AddressCountry country = AddressCountry::Usa);
+FAKER_CXX_EXPORT std::string_view state(AddressCountry country = AddressCountry::Usa);
 
 /**
  * @brief Returns a random city for given country.
@@ -71,7 +72,7 @@ std::string_view state(AddressCountry country = AddressCountry::Usa);
  * faker::location::city() // "Boston"
  * @endcode
  */
-std::string city(AddressCountry country = AddressCountry::Usa);
+FAKER_CXX_EXPORT std::string city(AddressCountry country = AddressCountry::Usa);
 
 /**
  * @brief Returns a random zip code for given country.
@@ -85,7 +86,7 @@ std::string city(AddressCountry country = AddressCountry::Usa);
  * faker::location::zipCode(Country::Poland) // "31-881"
  * @endcode
  */
-std::string zipCode(AddressCountry country = AddressCountry::Usa);
+FAKER_CXX_EXPORT std::string zipCode(AddressCountry country = AddressCountry::Usa);
 
 /**
  * @brief Returns a random street address for given country.
@@ -98,7 +99,7 @@ std::string zipCode(AddressCountry country = AddressCountry::Usa);
  * faker::location::streetAddress() // "34830 Erdman Hollow"
  * @endcode
  */
-std::string streetAddress(AddressCountry country = AddressCountry::Usa);
+FAKER_CXX_EXPORT std::string streetAddress(AddressCountry country = AddressCountry::Usa);
 
 /**
  * @brief Returns a random street for given country.
@@ -111,7 +112,7 @@ std::string streetAddress(AddressCountry country = AddressCountry::Usa);
  * faker::location::street() // "Schroeder Isle"
  * @endcode
  */
-std::string street(AddressCountry country = AddressCountry::Usa);
+FAKER_CXX_EXPORT std::string street(AddressCountry country = AddressCountry::Usa);
 
 /**
  * @brief Returns a random building number for given country.
@@ -124,7 +125,7 @@ std::string street(AddressCountry country = AddressCountry::Usa);
  * faker::location::buildingNumber() // "505"
  * @endcode
  */
-std::string buildingNumber(AddressCountry country = AddressCountry::Usa);
+FAKER_CXX_EXPORT std::string buildingNumber(AddressCountry country = AddressCountry::Usa);
 
 /**
  * @brief Returns a random secondary address number for given country.
@@ -138,7 +139,7 @@ std::string buildingNumber(AddressCountry country = AddressCountry::Usa);
  * faker::location::secondaryAddress() // "Apt. 861"
  * @endcode
  */
-std::string secondaryAddress(AddressCountry country = AddressCountry::Usa);
+FAKER_CXX_EXPORT std::string secondaryAddress(AddressCountry country = AddressCountry::Usa);
 
 /**
  * @brief Generates a random latitude.
@@ -151,7 +152,7 @@ std::string secondaryAddress(AddressCountry country = AddressCountry::Usa);
  * faker::location::latitude() // "-30.9501"
  * @endcode
  */
-std::string latitude(Precision precision = Precision::FourDp);
+FAKER_CXX_EXPORT std::string latitude(Precision precision = Precision::FourDp);
 
 /**
  * @brief Generates a random longitude.
@@ -164,7 +165,7 @@ std::string latitude(Precision precision = Precision::FourDp);
  * faker::location::longitude() // "-30.9501"
  * @endcode
  */
-std::string longitude(Precision precision = Precision::FourDp);
+FAKER_CXX_EXPORT std::string longitude(Precision precision = Precision::FourDp);
 
 /**
  * @brief Generates a random direction from cardinal and ordinal directions.
@@ -175,7 +176,7 @@ std::string longitude(Precision precision = Precision::FourDp);
  * faker::location::direction() // "North"
  * @endcode
  */
-std::string_view direction();
+FAKER_CXX_EXPORT std::string_view direction();
 
 /**
  * @brief Generates a random time zone.
@@ -186,5 +187,5 @@ std::string_view direction();
  * faker::location::timeZone() // "Europe/Warsaw"
  * @endcode
  */
-std::string_view timeZone();
+FAKER_CXX_EXPORT std::string_view timeZone();
 }

--- a/include/faker-cxx/Lorem.h
+++ b/include/faker-cxx/Lorem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include "faker-cxx/Export.h"
 
 namespace faker::lorem
 {
@@ -13,7 +14,7 @@ namespace faker::lorem
      * faker::lorem::word() // "temporibus"
      * @endcode
      */
-    std::string_view word();
+    FAKER_CXX_EXPORT std::string_view word();
 
     /**
      * @brief Returns a random lorem words.
@@ -26,7 +27,7 @@ namespace faker::lorem
      * faker::lorem::words() // "qui praesentium pariatur"
      * @endcode
      */
-    std::string words(unsigned numberOfWords = 3);
+    FAKER_CXX_EXPORT std::string words(unsigned numberOfWords = 3);
 
     /**
      * @brief Returns a random lorem sentence.
@@ -40,7 +41,7 @@ namespace faker::lorem
      * faker::lorem::sentence() // "Laborum voluptatem officiis est et."
      * @endcode
      */
-    std::string sentence(unsigned minNumberOfWords = 3, unsigned maxNumberOfWords = 10);
+    FAKER_CXX_EXPORT std::string sentence(unsigned minNumberOfWords = 3, unsigned maxNumberOfWords = 10);
 
     /**
      * @brief Returns a random lorem sentences.
@@ -54,7 +55,7 @@ namespace faker::lorem
      * faker::lorem::sentences(2, 2) // "Maxime vel numquam quibusdam. Dignissimos ex molestias quam nihil occaecati maiores."
      * @endcode
      */
-    std::string sentences(unsigned minNumberOfSentences = 2, unsigned maxNumberOfSentences = 6);
+    FAKER_CXX_EXPORT std::string sentences(unsigned minNumberOfSentences = 2, unsigned maxNumberOfSentences = 6);
 
     /**
      * @brief Generates a slugified text consisting of the given number of hyphen separated words.
@@ -67,7 +68,7 @@ namespace faker::lorem
      * faker::lorem::slug(5) // "delectus-totam-iusto-itaque-placeat"
      * @endcode
      */
-    std::string slug(unsigned numberOfWords = 3);
+    FAKER_CXX_EXPORT std::string slug(unsigned numberOfWords = 3);
 
     /**
      * @brief Returns a random lorem paragraph.
@@ -81,7 +82,7 @@ namespace faker::lorem
      * faker::lorem::paragraph() // "Animi possimus nemo consequuntur ut ea et tempore unde qui. Quis corporis esse."
      * @endcode
      */
-    std::string paragraph(unsigned minNumberOfSentences = 2, unsigned maxNumberOfSentences = 6);
+    FAKER_CXX_EXPORT std::string paragraph(unsigned minNumberOfSentences = 2, unsigned maxNumberOfSentences = 6);
 
     /**
      * @brief Returns a random lorem paragraphs.
@@ -98,5 +99,5 @@ namespace faker::lorem
      * // Sapiente deleniti et. Ducimus maiores eum. Rem dolorem itaque aliquam."
      * @endcode
      */
-    std::string paragraphs(unsigned minNumberOfParagraphs = 2, unsigned maxNumberOfParagraphs = 4);
+    FAKER_CXX_EXPORT std::string paragraphs(unsigned minNumberOfParagraphs = 2, unsigned maxNumberOfParagraphs = 4);
 }

--- a/include/faker-cxx/Medicine.h
+++ b/include/faker-cxx/Medicine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::medicine
 {
@@ -13,7 +14,7 @@ namespace faker::medicine
  * faker::medicine::condition() // "AIDS"
  * @endcode
  */
-std::string_view condition();
+FAKER_CXX_EXPORT std::string_view condition();
 
 /**
  * @brief Returns a random medical test
@@ -24,7 +25,7 @@ std::string_view condition();
  * faker::medicine::medicalTest() // "pulmonary auscultation"
  * @endcode
  */
-std::string_view medicalTest();
+FAKER_CXX_EXPORT std::string_view medicalTest();
 
 /**
  * @brief Returns a random Medical specialty
@@ -36,5 +37,5 @@ std::string_view medicalTest();
  * @endcode
  */
 
-std::string_view specialty();
+FAKER_CXX_EXPORT std::string_view specialty();
 }

--- a/include/faker-cxx/Movie.h
+++ b/include/faker-cxx/Movie.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::movie
 {
@@ -13,7 +14,7 @@ namespace faker::movie
  * faker::movie::genre() // "Drama"
  * @endcode
  */
-std::string_view genre();
+FAKER_CXX_EXPORT std::string_view genre();
 
 /**
  * @brief Returns a random movie title.
@@ -24,7 +25,7 @@ std::string_view genre();
  * faker::movie::movieTitle() // "Pulp Fiction"
  * @endcode
  */
-std::string_view movieTitle();
+FAKER_CXX_EXPORT std::string_view movieTitle();
 
 /**
  * @brief Returns a random tv show.
@@ -35,7 +36,7 @@ std::string_view movieTitle();
  * faker::movie::tvShow() // "The Sopranos"
  * @endcode
  */
-std::string_view tvShow();
+FAKER_CXX_EXPORT std::string_view tvShow();
 
 /**
  * @brief Returns a random movie director name.
@@ -46,7 +47,7 @@ std::string_view tvShow();
  * faker::movie::director() // "Quentin Tarantino"
  * @endcode
  */
-std::string_view director();
+FAKER_CXX_EXPORT std::string_view director();
 
 /**
  * @brief Returns a random actor name.
@@ -57,7 +58,7 @@ std::string_view director();
  * faker::movie::actor() // "John Travolta"
  * @endcode
  */
-std::string_view actor();
+FAKER_CXX_EXPORT std::string_view actor();
 
 /**
  * @brief Returns a random actress name.
@@ -68,5 +69,5 @@ std::string_view actor();
  * faker::movie::actress() // "Scarlett Johansson"
  * @endcode
  */
-std::string_view actress();
+FAKER_CXX_EXPORT std::string_view actress();
 }

--- a/include/faker-cxx/Music.h
+++ b/include/faker-cxx/Music.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::music
 {
@@ -13,7 +14,7 @@ namespace faker::music
      * faker::music::artist() // "Nirvana"
      * @endcode
      */
-    std::string_view artist();
+    FAKER_CXX_EXPORT std::string_view artist();
 
     /**
      * @brief Returns a random music genre.
@@ -24,7 +25,7 @@ namespace faker::music
      * faker::music::genre() // "Rock"
      * @endcode
      */
-    std::string_view genre();
+    FAKER_CXX_EXPORT std::string_view genre();
 
     /**
      * @brief Returns a random song name.
@@ -35,5 +36,5 @@ namespace faker::music
      * faker::music::songName() // "Light My Fire"
      * @endcode
      */
-    std::string_view songName();
+    FAKER_CXX_EXPORT std::string_view songName();
 }

--- a/include/faker-cxx/Number.h
+++ b/include/faker-cxx/Number.h
@@ -6,7 +6,7 @@
 
 namespace faker::number
 {
-  
+
 /**
  * @brief Generates a random integer number in the given range, bounds included.
  *
@@ -18,7 +18,7 @@ namespace faker::number
  * @throws std::invalid_argument if min is greater than max.
  *
  * @return T a random integer number
- * 
+ *
  * @code
  * faker::number::integer(5, 10) // 7
  * @endcode
@@ -49,7 +49,7 @@ I integer(I min, I max)
  * @see integer<I>(I)
  *
  * @return T a random integer number
- * 
+ *
  * @code
  * faker::number::integer(10) // 5
  * @endcode
@@ -71,7 +71,7 @@ I integer(I max)
  * @throws std::invalid_argument if min is greater than max.
  *
  * @return F a random decimal number.
- * 
+ *
  * @code
  * faker::number::decimal(10.2, 17.7) // 15.6
  * @encode
@@ -101,7 +101,7 @@ F decimal(F min, F max)
      * @see decimal<F>(F)
      *
      * @return F, a random decimal number.
-     * 
+     *
      * @code
      * faker::number::decimal(20.5) // 17.2
      * @encode

--- a/include/faker-cxx/Person.h
+++ b/include/faker-cxx/Person.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string_view>
 
+#include "faker-cxx/Export.h"
 #include "types/Country.h"
 
 namespace faker::person
@@ -26,7 +27,7 @@ enum class Language;
      * faker::person::firstName(Country::England, Sex::Male) // "Arthur"
      * @endcode
      */
-    std::string_view firstName(std::optional<Country> country = std::nullopt,
+    FAKER_CXX_EXPORT std::string_view firstName(std::optional<Country> country = std::nullopt,
                                       std::optional<Sex> sex = std::nullopt);
 
     /**
@@ -41,7 +42,7 @@ enum class Language;
      * faker::person::lastName() // "Peterson"
      * @endcode
      */
-    std::string_view lastName(std::optional<Country> country = std::nullopt,
+    FAKER_CXX_EXPORT std::string_view lastName(std::optional<Country> country = std::nullopt,
                                      std::optional<Sex> sex = std::nullopt);
 
     /**
@@ -58,7 +59,7 @@ enum class Language;
      * faker::person::fullName(Country::England, Sex::Male) // "Samuel Walker"
      * @endcode
      */
-    std::string fullName(std::optional<Country> country = std::nullopt, std::optional<Sex> sex = std::nullopt);
+    FAKER_CXX_EXPORT std::string fullName(std::optional<Country> country = std::nullopt, std::optional<Sex> sex = std::nullopt);
 
     /**
      * @brief Returns a random name prefix.
@@ -73,7 +74,7 @@ enum class Language;
      * faker::person::prefix(Sex::Male) // "Mr."
      * @endcode
      */
-    std::string_view prefix(std::optional<Country> countryOpt = std::nullopt,
+    FAKER_CXX_EXPORT std::string_view prefix(std::optional<Country> countryOpt = std::nullopt,
                                    std::optional<Sex> sex = std::nullopt);
 
     /**
@@ -85,7 +86,7 @@ enum class Language;
      * faker::person::suffix() // "Jr."
      * @endcode
      */
-    std::string_view suffix(std::optional<Country> countryOpt = std::nullopt,
+    FAKER_CXX_EXPORT std::string_view suffix(std::optional<Country> countryOpt = std::nullopt,
                                    std::optional<Sex> sex = std::nullopt);
 
     /**
@@ -97,7 +98,7 @@ enum class Language;
      * faker::person::bio() //"Developer"
      * @endcode
      */
-    std::string bio();
+    FAKER_CXX_EXPORT std::string bio();
 
     /**
      * @brief Returns a sex.
@@ -108,7 +109,7 @@ enum class Language;
      * faker::person::sex() // "Male"
      * @endcode
      */
-    std::string_view sex(std::optional<Language> language = std::nullopt);
+    FAKER_CXX_EXPORT std::string_view sex(std::optional<Language> language = std::nullopt);
 
     /**
      * @brief Returns a random gender.
@@ -119,7 +120,7 @@ enum class Language;
      * faker::person::gender() // "Transexual woman"
      * @endcode
      */
-    std::string_view gender();
+    FAKER_CXX_EXPORT std::string_view gender();
 
     /**
      * @brief Returns a random job title.
@@ -130,7 +131,7 @@ enum class Language;
      * faker::person::jobTitle() // "Global Accounts Engineer"
      * @endcode
      */
-    std::string jobTitle();
+    FAKER_CXX_EXPORT std::string jobTitle();
 
     /**
      * @brief Returns a random job descriptor.
@@ -141,7 +142,7 @@ enum class Language;
      * faker::person::jobDescriptor() // "Senior"
      * @endcode
      */
-    std::string_view jobDescriptor();
+    FAKER_CXX_EXPORT std::string_view jobDescriptor();
 
     /**
      * @brief Returns a random job area.
@@ -152,7 +153,7 @@ enum class Language;
      * faker::person::jobArea() // "Software"
      * @endcode
      */
-    std::string_view jobArea();
+    FAKER_CXX_EXPORT std::string_view jobArea();
 
     /**
      * @brief Returns a random job type.
@@ -163,7 +164,7 @@ enum class Language;
      * faker::person::jobType() // "Engineer"
      * @endcode
      */
-    std::string_view jobType();
+    FAKER_CXX_EXPORT std::string_view jobType();
 
     /**
      * @brief Returns a random hobby.
@@ -174,7 +175,7 @@ enum class Language;
      * faker::person::hobby() // "Gaming"
      * @endcode
      */
-    std::string_view hobby();
+    FAKER_CXX_EXPORT std::string_view hobby();
 
     /**
      * @brief Returns a random language.
@@ -185,7 +186,7 @@ enum class Language;
      * faker::person::language() // "Polish"
      * @endcode
      */
-    std::string_view language();
+    FAKER_CXX_EXPORT std::string_view language();
 
     /**
      * @brief Returns a random nationality.
@@ -196,7 +197,7 @@ enum class Language;
      * faker::person::nationality() // "Romanian"
      * @endcode
      */
-    std::string_view nationality();
+    FAKER_CXX_EXPORT std::string_view nationality();
 
     /**
      * @brief Returns a random SSN.
@@ -210,7 +211,7 @@ enum class Language;
      * faker::person::ssn(SsnCountry::Polish) // "95111901567"
      * @endcode
      */
-    std::string ssn(std::optional<SsnCountry> country = std::nullopt);
+    FAKER_CXX_EXPORT std::string ssn(std::optional<SsnCountry> country = std::nullopt);
 
     /**
      * @brief Returns a random Western Zodiac
@@ -221,7 +222,7 @@ enum class Language;
      * faker::person::westernZodiac() // "Virgo"
      * @endcode
      */
-    std::string_view westernZodiac();
+    FAKER_CXX_EXPORT std::string_view westernZodiac();
 
     /**
      * @brief Returns a random Chinese Zodiac
@@ -232,7 +233,7 @@ enum class Language;
      * faker::person::chineseZodiac() // "Dragon"
      * @endcode
      */
-    std::string_view chineseZodiac();
+    FAKER_CXX_EXPORT std::string_view chineseZodiac();
 
     /**
      * @brief Returns a random passport number from a given country
@@ -243,7 +244,7 @@ enum class Language;
      * faker::person::passport(PassportCountry::Romania) // "12345678"
      * @endcode
      */
-    std::string passport(std::optional<PassportCountry> country = std::nullopt);
+    FAKER_CXX_EXPORT std::string passport(std::optional<PassportCountry> country = std::nullopt);
 
 enum class PassportCountry
 {

--- a/include/faker-cxx/Phone.h
+++ b/include/faker-cxx/Phone.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include "faker-cxx/Export.h"
 
 namespace faker::phone
 {
@@ -21,7 +22,7 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::number("+48 91 ### ## ##") // "+48 91 463 61 70"
      * @endcode
      */
-    std::string number(std::optional<std::string> = std::nullopt);
+    FAKER_CXX_EXPORT std::string number(std::optional<std::string> = std::nullopt);
 
     /**
      * @brief Returns a random phone platform.
@@ -32,7 +33,7 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::platform() // "iOS"
      * @endcode
      */
-    std::string_view platform();
+    FAKER_CXX_EXPORT std::string_view platform();
 
     /**
      * @brief Returns a random phone model.
@@ -43,7 +44,7 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::modelName() // "Samsung Galaxy S22"
      * @endcode
      */
-    std::string_view modelName();
+    FAKER_CXX_EXPORT std::string_view modelName();
 
     /**
      * @brief Returns a random phone manufacturer.
@@ -54,7 +55,7 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::manufacturer() // "Sony"
      * @endcode
      */
-    std::string_view manufacturer();
+    FAKER_CXX_EXPORT std::string_view manufacturer();
 
     /**
      * @brief Returns a random phone number based on country phone number template.
@@ -67,7 +68,7 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::number(PhoneNumberCountryFormat::Usa) // "+1 (395) 714-1494"
      * @endcode
      */
-    std::string number(PhoneNumberCountryFormat format);
+    FAKER_CXX_EXPORT std::string number(PhoneNumberCountryFormat format);
 
     /**
      * @brief Returns IMEI number.
@@ -78,7 +79,7 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::imei() // "13-850175-913761-7"
      * @endcode
      */
-    std::string imei();
+    FAKER_CXX_EXPORT std::string imei();
 
     /**
      * @brief returns a random country area code
@@ -89,9 +90,9 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::areaCode() // "+1"
      * @endcode
      */
-    std::string_view areaCode();
+    FAKER_CXX_EXPORT std::string_view areaCode();
 
-    std::unordered_map<PhoneNumberCountryFormat, std::string> createPhoneNumberFormatMap();
+    FAKER_CXX_EXPORT std::unordered_map<PhoneNumberCountryFormat, std::string> createPhoneNumberFormatMap();
 
 enum class PhoneNumberCountryFormat
 {

--- a/include/faker-cxx/Plant.h
+++ b/include/faker-cxx/Plant.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::plant
 {
@@ -13,7 +14,7 @@ namespace faker::plant
  * faker::plant::tree() // "Oak"
  * @endcode
  */
-std::string_view tree();
+FAKER_CXX_EXPORT std::string_view tree();
 
 /**
  * @brief Returns a random species of flower.
@@ -24,7 +25,7 @@ std::string_view tree();
  * faker::plant::flower() // "Rose"
  * @endcode
  */
-std::string_view flower();
+FAKER_CXX_EXPORT std::string_view flower();
 
 /**
  * @brief Returns a random species of shrub.
@@ -35,7 +36,7 @@ std::string_view flower();
  * faker::plant::shrub() // "Azalea"
  * @endcode
  */
-std::string_view shrub();
+FAKER_CXX_EXPORT std::string_view shrub();
 
 /**
  * @brief Returns a random species of grass.
@@ -46,7 +47,7 @@ std::string_view shrub();
  * faker::plant::grass() // "Kentucky Bluegrass"
  * @endcode
  */
-std::string_view grass();
+FAKER_CXX_EXPORT std::string_view grass();
 
 /**
  * @brief Returns a random species of fern.
@@ -57,7 +58,7 @@ std::string_view grass();
  * faker::plant::fern() // "Maidenhair"
  * @endcode
  */
-std::string_view fern();
+FAKER_CXX_EXPORT std::string_view fern();
 
 /**
  * @brief Returns a random species of succulent.
@@ -68,7 +69,7 @@ std::string_view fern();
  * faker::plant::succulent() // "Aloe Vera"
  * @endcode
  */
-std::string_view succulent();
+FAKER_CXX_EXPORT std::string_view succulent();
 
 /**
  * @brief Returns a random species of vine.
@@ -79,7 +80,7 @@ std::string_view succulent();
  * faker::plant::vine() // "Ivy"
  * @endcode
  */
-std::string_view vine();
+FAKER_CXX_EXPORT std::string_view vine();
 
 /**
  * @brief Returns a random type of plant.
@@ -90,5 +91,5 @@ std::string_view vine();
  * faker::plant::type() // "tree"
  * @endcode
  */
-std::string_view plantType();
+FAKER_CXX_EXPORT std::string_view plantType();
 }

--- a/include/faker-cxx/Science.h
+++ b/include/faker-cxx/Science.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::science
 {
-struct ChemicalElement
+struct FAKER_CXX_EXPORT ChemicalElement
 {
     std::string_view name;
     std::string_view symbol;
@@ -21,9 +22,9 @@ struct ChemicalElement
  * table.
  * @endcode
  */
-ChemicalElement chemicalElement();
+FAKER_CXX_EXPORT ChemicalElement chemicalElement();
 
-struct Unit
+struct FAKER_CXX_EXPORT Unit
 {
     std::string_view name;
     std::string_view symbol;
@@ -39,7 +40,7 @@ struct Unit
  * faker::science::unit() // Object of Unit containing info about a random unit of measurement.
  * @endcode
  */
-Unit unit();
+FAKER_CXX_EXPORT Unit unit();
 
 /**
  * @brief Returns a unit of measurement for either distance.
@@ -51,7 +52,7 @@ Unit unit();
  * distance.
  * @endcode
  */
-Unit distanceUnit();
+FAKER_CXX_EXPORT Unit distanceUnit();
 
 /**
  * @brief Returns a unit of measurement for either time.
@@ -62,7 +63,7 @@ Unit distanceUnit();
  * faker::science::timeUnit() // Object of Unit containing info about a random unit of measurement used to measure time.
  * @endcode
  */
-Unit timeUnit();
+FAKER_CXX_EXPORT Unit timeUnit();
 
 /**
  * @brief Returns a unit of measurement for either mass.
@@ -73,7 +74,7 @@ Unit timeUnit();
  * faker::science::massUnit() // Object of Unit containing info about a random unit of measurement used to measure mass.
  * @endcode
  */
-Unit massUnit();
+FAKER_CXX_EXPORT Unit massUnit();
 
 /**
  * @brief Returns a unit of measurement for either temp.
@@ -84,7 +85,7 @@ Unit massUnit();
  * faker::science::tempUnit() // Object of Unit containing info about a random unit of measurement used to measure temp.
  * @endcode
  */
-Unit tempUnit();
+FAKER_CXX_EXPORT Unit tempUnit();
 
 /**
  * @brief Returns a unit of measurement for either current.
@@ -96,5 +97,5 @@ Unit tempUnit();
  * current.
  * @endcode
  */
-Unit currentUnit();
+FAKER_CXX_EXPORT Unit currentUnit();
 }

--- a/include/faker-cxx/Sport.h
+++ b/include/faker-cxx/Sport.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::sport
 {
@@ -13,8 +14,8 @@ namespace faker::sport
      * faker::sport::sport() // "football"
      * @endcode
      */
-    
-    std::string_view sportName();
+
+    FAKER_CXX_EXPORT std::string_view sportName();
 
     /**
      * @brief Returns a random soccer team.
@@ -25,7 +26,7 @@ namespace faker::sport
      * faker::sport::soccerTeam() // "Manchester United"
      * @endcode
      */
-    std::string_view soccerTeam();
+    FAKER_CXX_EXPORT std::string_view soccerTeam();
 
     /**
      * @brief Returns a random male athlete.
@@ -36,7 +37,7 @@ namespace faker::sport
      * faker::sport::maleAthlete() // "Cristiano Ronaldo"
      * @endcode
      */
-    std::string_view maleAthlete();
+    FAKER_CXX_EXPORT std::string_view maleAthlete();
 
     /**
      * @brief Returns a random female athlete.
@@ -47,7 +48,7 @@ namespace faker::sport
      * faker::sport::femaleAthlete() // "Serena Williams"
      * @endcode
      */
-    std::string_view femaleAthlete();
+    FAKER_CXX_EXPORT std::string_view femaleAthlete();
 
     /**
      * @brief Returns a random Sport Event.
@@ -58,5 +59,5 @@ namespace faker::sport
      * faker::sport::sportEvent() // "Super Bowl"
      * @endcode
      */
-    std::string_view sportEvent();
+    FAKER_CXX_EXPORT std::string_view sportEvent();
 }

--- a/include/faker-cxx/String.h
+++ b/include/faker-cxx/String.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 
+#include "faker-cxx/Export.h"
 #include "RandomGenerator.h"
 #include "types/Hex.h"
 
@@ -19,7 +20,7 @@ enum class StringCasing
     Upper
 };
 
-struct CharCount
+struct FAKER_CXX_EXPORT CharCount
 {
     unsigned int atLeastCount{(std::numeric_limits<unsigned int>::min)()};
     unsigned int atMostCount{(std::numeric_limits<unsigned int>::max)()};
@@ -46,7 +47,7 @@ using GuaranteeMap = std::map<char, CharCount>;
  * faker::string::isValidGuarantee(guarantee,targetCharacters,length) // false
  * @endcode
  */
-bool isValidGuarantee(GuaranteeMap& guarantee, std::set<char>& targetCharacters, unsigned int length);
+FAKER_CXX_EXPORT bool isValidGuarantee(GuaranteeMap& guarantee, std::set<char>& targetCharacters, unsigned int length);
 
 /**
  * @brief Generates the least required string for a given guarantee map
@@ -60,7 +61,7 @@ bool isValidGuarantee(GuaranteeMap& guarantee, std::set<char>& targetCharacters,
  * faker::string::generateAtLeastString(guarantee);
  * @endcode
  */
-std::string generateAtLeastString(const GuaranteeMap& guarantee);
+FAKER_CXX_EXPORT std::string generateAtLeastString(const GuaranteeMap& guarantee);
 
     // namespace {
     //     std::string generateStringWithGuarantee(GuaranteeMap& guarantee, std::set<char>& targetCharacters,
@@ -134,7 +135,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::sample(5) // "6Bye8"
      * @endcode
      */
-    std::string sample(unsigned length = 10);
+    FAKER_CXX_EXPORT std::string sample(unsigned length = 10);
 
     /**
      * @brief Returns a string containing UTF-16 chars between 33 and 125 (`!` to `}`).
@@ -149,7 +150,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::sample({{'|' ,{2,2}},{'^',{0,0}},{':',{1,8}}}, 8) // "|6Bye8:|"
      * @endcode
      */
-    std::string sample(GuaranteeMap&& guarantee, unsigned length = 10);
+    FAKER_CXX_EXPORT std::string sample(GuaranteeMap&& guarantee, unsigned length = 10);
 
     /**
      * @brief Generates a string consisting of given characters.
@@ -164,7 +165,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::fromCharacters("qwerty", 5) // "qrwqt"
      * @endcode
      */
-    std::string fromCharacters(const std::string& characters, unsigned length = 1);
+    FAKER_CXX_EXPORT std::string fromCharacters(const std::string& characters, unsigned length = 1);
 
     /**
      * @brief Generates a string consisting of given characters.
@@ -180,7 +181,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::fromCharacters({{'q',{2,2}},{'e',{1,5}}}, "qwerty", 8) // "yqreqety"
      * @endcode
      */
-    std::string fromCharacters(GuaranteeMap&& guarantee, const std::string& characters, unsigned length = 1);
+    FAKER_CXX_EXPORT std::string fromCharacters(GuaranteeMap&& guarantee, const std::string& characters, unsigned length = 1);
 
     /**
      * @brief Generates a string consisting of letters in the English alphabet.
@@ -198,7 +199,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::alpha(4, StringCasing::Lower) // "brpt"
      * @endcode
      */
-    std::string alpha(unsigned length = 1, StringCasing casing = StringCasing::Mixed,
+    FAKER_CXX_EXPORT std::string alpha(unsigned length = 1, StringCasing casing = StringCasing::Mixed,
                              const std::string& excludeCharacters = "");
 
     /**
@@ -216,7 +217,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::alpha({{'a',{0,0}},{'b',{3,3}},{'c', {0,2}}}, 10, StringCasing::Lower) // "bicnmmkbbp"
      * @endcode
      */
-    std::string alpha(GuaranteeMap&& guarantee, unsigned length = 1, StringCasing casing = StringCasing::Mixed);
+    FAKER_CXX_EXPORT std::string alpha(GuaranteeMap&& guarantee, unsigned length = 1, StringCasing casing = StringCasing::Mixed);
 
     /**
      * @brief Generates a string consisting of alpha characters and digits.
@@ -234,7 +235,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::alphanumeric(4, StringCasing::Lower) // "1nrq"
      * @endcode
      */
-    std::string alphanumeric(unsigned length = 1, StringCasing casing = StringCasing::Mixed,
+    FAKER_CXX_EXPORT std::string alphanumeric(unsigned length = 1, StringCasing casing = StringCasing::Mixed,
                                     const std::string& excludeCharacters = "");
 
     /**
@@ -252,7 +253,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::alphanumeric({{'a',{0,2}},{'2',{0,3}},{'z',{3,5}}}, 10, StringCasing::Lower) // "z1naazrqz0"
      * @endcode
      */
-    std::string alphanumeric(GuaranteeMap&& guarantee, unsigned length = 1,
+    FAKER_CXX_EXPORT std::string alphanumeric(GuaranteeMap&& guarantee, unsigned length = 1,
                                     StringCasing casing = StringCasing::Mixed);
 
     /**
@@ -269,7 +270,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::numeric(6, false) // "254429"
      * @endcode
      */
-    std::string numeric(unsigned length = 1, bool allowLeadingZeros = true);
+    FAKER_CXX_EXPORT std::string numeric(unsigned length = 1, bool allowLeadingZeros = true);
 
     /**
      * @brief Generates a given length string of digits.
@@ -286,7 +287,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::numeric({'0',{0,0}}, {'4',{1,1}}, 6, false) // "854829"
      * @endcode
      */
-    std::string numeric(GuaranteeMap&& guarantee, unsigned length = 1, bool allowLeadingZeros = true);
+    FAKER_CXX_EXPORT std::string numeric(GuaranteeMap&& guarantee, unsigned length = 1, bool allowLeadingZeros = true);
 
     /**
      * @brief Generates a hexadecimal string.
@@ -304,7 +305,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::hexadecimal(6, HexCasing::Lower, HexPrefix::None) // "e3f380"
      * @endcode
      */
-    std::string hexadecimal(unsigned length = 1, HexCasing casing = HexCasing::Lower,
+    FAKER_CXX_EXPORT std::string hexadecimal(unsigned length = 1, HexCasing casing = HexCasing::Lower,
                                    HexPrefix prefix = HexPrefix::ZeroX);
 
     /**
@@ -320,7 +321,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::hexadecimal(0, 255) // "9d"
      * @endcode
      */
-    std::string hexadecimal(std::optional<int> min = std::nullopt, std::optional<int> max = std::nullopt);
+    FAKER_CXX_EXPORT std::string hexadecimal(std::optional<int> min = std::nullopt, std::optional<int> max = std::nullopt);
 
     /**
      * @brief Generates a hexadecimal string.
@@ -339,7 +340,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::hexadecimal({'1', {1,4}, {'2', {1, 4}, {'c', {1,1}}, 6, HexCasing::Lower, HexPrefix::None) // "121a1c"
      * @endcode
      */
-    std::string hexadecimal(GuaranteeMap&& guarantee, unsigned length = 1, HexCasing casing = HexCasing::Lower,
+    FAKER_CXX_EXPORT std::string hexadecimal(GuaranteeMap&& guarantee, unsigned length = 1, HexCasing casing = HexCasing::Lower,
                                    HexPrefix prefix = HexPrefix::ZeroX);
 
     /**
@@ -353,7 +354,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::binary(8) // "0b01110101"
      * @endcode
      */
-    std::string binary(unsigned length = 1);
+    FAKER_CXX_EXPORT std::string binary(unsigned length = 1);
 
     /**
      * @brief Generates a binary string.
@@ -367,7 +368,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::binary({'1',{7,8}}, 8) // "0b11110111"
      * @endcode
      */
-    std::string binary(GuaranteeMap&& guarantee, unsigned length = 1);
+    FAKER_CXX_EXPORT std::string binary(GuaranteeMap&& guarantee, unsigned length = 1);
 
     /**
      * @brief Generates an octal string.
@@ -380,7 +381,7 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::octal(8) // "0o52561721"
      * @endcode
      */
-    std::string octal(unsigned length = 1);
+    FAKER_CXX_EXPORT std::string octal(unsigned length = 1);
 
     /**
      * @brief Generates an octal string.
@@ -394,5 +395,5 @@ std::string generateAtLeastString(const GuaranteeMap& guarantee);
      * faker::string::octal({'4',{4,5}}, 8) // "0o42444041"
      * @endcode
      */
-    std::string octal(GuaranteeMap&& guarantee, unsigned length = 1);
+    FAKER_CXX_EXPORT std::string octal(GuaranteeMap&& guarantee, unsigned length = 1);
 }

--- a/include/faker-cxx/System.h
+++ b/include/faker-cxx/System.h
@@ -3,10 +3,11 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::system
 {
-struct FileOptions
+struct FAKER_CXX_EXPORT FileOptions
 {
     int extensionCount = 1;
 
@@ -26,13 +27,13 @@ enum class FileType
     Video,
 };
 
-struct CronOptions
+struct FAKER_CXX_EXPORT CronOptions
 {
     bool includeYear = false;
     bool includeNonStandard = false;
 };
 
-struct NetworkInterfaceOptions
+struct FAKER_CXX_EXPORT NetworkInterfaceOptions
 {
     std::optional<std::string> interfaceType;
     std::optional<std::string> interfaceSchema;
@@ -57,7 +58,7 @@ struct NetworkInterfaceOptions
  * faker::system::fileName(options) // "sparkle.png.pdf"
  * @endcode
  */
-std::string fileName(const FileOptions& options = {});
+FAKER_CXX_EXPORT std::string fileName(const FileOptions& options = {});
 
 /**
  * @brief Returns a file extension.
@@ -70,7 +71,7 @@ std::string fileName(const FileOptions& options = {});
  * faker::system::fileExtension(MimeType::Image) // "png"
  * @endcode
  */
-std::string fileExtension(const std::optional<FileType>& mimeType = std::nullopt);
+FAKER_CXX_EXPORT std::string fileExtension(const std::optional<FileType>& mimeType = std::nullopt);
 
 /**
  * Returns a random file name with a given extension or a commonly used extension.
@@ -84,7 +85,7 @@ std::string fileExtension(const std::optional<FileType>& mimeType = std::nullopt
  * faker::system::commonFileName("txt") // "global_borders_wyoming.txt"
  * @endcode
  */
-std::string commonFileName(const std::optional<std::string>& ext = std::nullopt);
+FAKER_CXX_EXPORT std::string commonFileName(const std::optional<std::string>& ext = std::nullopt);
 
 /**
  * Returns a commonly used file extension.
@@ -95,7 +96,7 @@ std::string commonFileName(const std::optional<std::string>& ext = std::nullopt)
  * faker::system::commonFileExtension() // "gif"
  * @endcode
  */
-std::string_view commonFileExtension();
+FAKER_CXX_EXPORT std::string_view commonFileExtension();
 
 /**
  * Returns a mime-type.
@@ -106,7 +107,7 @@ std::string_view commonFileExtension();
  * faker::system::mimeType() // "video/vnd.vivo"
  * @endcode
  */
-std::string_view mimeType();
+FAKER_CXX_EXPORT std::string_view mimeType();
 
 /**
  * Returns a commonly used file type.
@@ -117,7 +118,7 @@ std::string_view mimeType();
  * faker::system::fileType() // "audio"
  * @endcode
  */
-std::string_view fileType();
+FAKER_CXX_EXPORT std::string_view fileType();
 
 /**
  * Returns a directory path.
@@ -128,7 +129,7 @@ std::string_view fileType();
  * faker::system::directoryPath() // "/etc/mail"
  * @endcode
  */
-std::string_view directoryPath();
+FAKER_CXX_EXPORT std::string_view directoryPath();
 
 /**
  * Returns a file path.
@@ -139,7 +140,7 @@ std::string_view directoryPath();
  * faker::system::filePath() // "/usr/local/src/money.dotx"
  * @endcode
  */
-std::string filePath();
+FAKER_CXX_EXPORT std::string filePath();
 
 /**
  * Returns a semantic version.
@@ -150,7 +151,7 @@ std::string filePath();
  * faker::system::semver() // "1.1.2"
  * @endcode
  */
-std::string semver();
+FAKER_CXX_EXPORT std::string semver();
 
 /**
  * Returns a random network interface.
@@ -178,7 +179,7 @@ std::string semver();
  * faker::system::networkInterface(options) // "enp1s9f1d2"
  * @endcode
  */
-std::string networkInterface(const std::optional<NetworkInterfaceOptions>& options = {});
+FAKER_CXX_EXPORT std::string networkInterface(const std::optional<NetworkInterfaceOptions>& options = {});
 
 /**
  * Returns a random cron expression.
@@ -210,5 +211,5 @@ std::string networkInterface(const std::optional<NetworkInterfaceOptions>& optio
  * std::string cronExpr = faker::system::cron(options) // "@reboot"
  * @endcode
  */
-std::string cron(const CronOptions& options = {});
+FAKER_CXX_EXPORT std::string cron(const CronOptions& options = {});
 }

--- a/include/faker-cxx/Vehicle.h
+++ b/include/faker-cxx/Vehicle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::vehicle
 {
@@ -13,7 +14,7 @@ namespace faker::vehicle
      * faker::vehicle::bicycle() // "Electric bike"
      * @endcode
      */
-    std::string_view bicycle();
+    FAKER_CXX_EXPORT std::string_view bicycle();
 
     /**
      * @brief Returns a random vehicle color.
@@ -24,7 +25,7 @@ namespace faker::vehicle
      * faker::vehicle::color() // "Silver"
      * @endcode
      */
-    std::string_view color();
+    FAKER_CXX_EXPORT std::string_view color();
 
     /**
      * @brief Returns a random vehicle fuel.
@@ -35,7 +36,7 @@ namespace faker::vehicle
      * faker::vehicle::fuel() // "Diesel"
      * @endcode
      */
-    std::string_view fuel();
+    FAKER_CXX_EXPORT std::string_view fuel();
 
     /**
      * @brief Returns a random vehicle(car) manufacturer.
@@ -46,7 +47,7 @@ namespace faker::vehicle
      * faker::vehicle::manufacturer() // "Ferrari"
      * @endcode
      */
-    std::string_view manufacturer();
+    FAKER_CXX_EXPORT std::string_view manufacturer();
 
     /**
      * @brief Returns a random vehicle(car) model.
@@ -57,7 +58,7 @@ namespace faker::vehicle
      * faker::vehicle::model() // "Fiesta"
      * @endcode
      */
-    std::string_view model();
+    FAKER_CXX_EXPORT std::string_view model();
 
     /**
      * @brief Returns a random vehicle type.
@@ -68,7 +69,7 @@ namespace faker::vehicle
      * faker::vehicle::type() // "Van"
      * @endcode
      */
-    std::string_view type();
+    FAKER_CXX_EXPORT std::string_view type();
 
     /**
      * @brief Returns a random vehicle(car).
@@ -79,7 +80,7 @@ namespace faker::vehicle
      * faker::vehicle::vehicleName() // "BMW Explorer"
      * @endcode
      */
-    std::string vehicleName();
+    FAKER_CXX_EXPORT std::string vehicleName();
 
     /**
      * @brief Returns a vehicle identification number (VIN).
@@ -90,7 +91,7 @@ namespace faker::vehicle
      * faker::vehicle::vin() // "YV1MH682762184654"
      * @endcode
      */
-    std::string vin();
+    FAKER_CXX_EXPORT std::string vin();
 
     /**
      * @brief Returns a vehicle registration number (Vehicle Registration Mark - VRM).
@@ -101,5 +102,5 @@ namespace faker::vehicle
      * faker::vehicle::vrm() // "MF56UPA"
      * @endcode
      */
-    std::string vrm();
+    FAKER_CXX_EXPORT std::string vrm();
 }

--- a/include/faker-cxx/VideoGame.h
+++ b/include/faker-cxx/VideoGame.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
+
 
 namespace faker::videogame
 {
@@ -13,7 +15,7 @@ namespace faker::videogame
      * faker::videogame::gameTitle() // "Rayman Arena"
      * @endcode
      */
-    std::string_view gameTitle();
+    FAKER_CXX_EXPORT std::string_view gameTitle();
 
     /**
      * @brief Returns a random video game genre.
@@ -24,7 +26,7 @@ namespace faker::videogame
      * faker::videogame::genre() // "Platformer"
      * @endcode
      */
-    std::string_view genre();
+    FAKER_CXX_EXPORT std::string_view genre();
 
     /**
      * @brief Returns a random video game platform.
@@ -35,7 +37,7 @@ namespace faker::videogame
      * faker::videogame::platform() // "Playstation 5"
      * @endcode
      */
-    std::string_view platform();
+    FAKER_CXX_EXPORT std::string_view platform();
 
     /**
      * @brief Returns a random video game studio name.
@@ -46,5 +48,5 @@ namespace faker::videogame
      * faker::videogame::studioName() // "Activision Blizzard"
      * @endcode
      */
-    std::string_view studioName();
+    FAKER_CXX_EXPORT std::string_view studioName();
 }

--- a/include/faker-cxx/Weather.h
+++ b/include/faker-cxx/Weather.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::weather
 {
@@ -13,5 +14,5 @@ namespace faker::weather
  * faker::weather::weatherDescription(); // "Sunny"
  * @endcode
  */
-std::string_view weatherDescription();
+FAKER_CXX_EXPORT std::string_view weatherDescription();
 }

--- a/include/faker-cxx/Word.h
+++ b/include/faker-cxx/Word.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include "faker-cxx/Export.h"
 
 namespace faker::word
 {
@@ -19,7 +20,7 @@ namespace faker::word
  * faker::word::sample(5) // "spell"
  * @endcode
  */
-std::string_view sample(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view sample(std::optional<unsigned> length = std::nullopt);
 
 /**
  * @brief Returns a string containing a number of space separated random words.
@@ -33,7 +34,7 @@ std::string_view sample(std::optional<unsigned> length = std::nullopt);
  * faker::word::words(5) // "before hourly patiently dribble equal"
  * @endcode
  */
-std::string words(unsigned numberOfWords = 1);
+FAKER_CXX_EXPORT std::string words(unsigned numberOfWords = 1);
 
 /**
  * @brief Returns a random adjective.
@@ -48,7 +49,7 @@ std::string words(unsigned numberOfWords = 1);
  * faker::word::adjective(3) // "bad"
  * @endcode
  */
-std::string_view adjective(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view adjective(std::optional<unsigned> length = std::nullopt);
 
 /**
  * @brief Returns a random adverb.
@@ -63,7 +64,7 @@ std::string_view adjective(std::optional<unsigned> length = std::nullopt);
  * faker::word::adverb(5) // "almost"
  * @endcode
  */
-std::string_view adverb(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view adverb(std::optional<unsigned> length = std::nullopt);
 
 /**
  * @brief Returns a random conjunction.
@@ -78,7 +79,7 @@ std::string_view adverb(std::optional<unsigned> length = std::nullopt);
  * faker::word::conjunction(6) // "indeed"
  * @endcode
  */
-std::string_view conjunction(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view conjunction(std::optional<unsigned> length = std::nullopt);
 
 /**
  * @brief Returns a random interjection.
@@ -93,7 +94,7 @@ std::string_view conjunction(std::optional<unsigned> length = std::nullopt);
  * faker::word::interjection(4) // "yuck"
  * @endcode
  */
-std::string_view interjection(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view interjection(std::optional<unsigned> length = std::nullopt);
 
 /**
  * @brief Returns a random noun.
@@ -108,7 +109,7 @@ std::string_view interjection(std::optional<unsigned> length = std::nullopt);
  * faker::word::noun(8) // "distance"
  * @endcode
  */
-std::string_view noun(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view noun(std::optional<unsigned> length = std::nullopt);
 
 /**
  * @brief Returns a random preposition.
@@ -123,7 +124,7 @@ std::string_view noun(std::optional<unsigned> length = std::nullopt);
  * faker::word::preposition(4) // "from"
  * @endcode
  */
-std::string_view preposition(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view preposition(std::optional<unsigned> length = std::nullopt);
 
 /**
  * @brief Returns a random verb.
@@ -138,5 +139,5 @@ std::string_view preposition(std::optional<unsigned> length = std::nullopt);
  * faker::word::verb(9) // "stabilise"
  * @endcode
  */
-std::string_view verb(std::optional<unsigned> length = std::nullopt);
+FAKER_CXX_EXPORT std::string_view verb(std::optional<unsigned> length = std::nullopt);
 }

--- a/src/common/FormatHelper.h
+++ b/src/common/FormatHelper.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "faker-cxx/types/Precision.h"
+#include "faker-cxx/Export.h"
 
 #if !defined(HAS_STD_FORMAT)
 #include <fmt/chrono.h>
@@ -34,13 +35,13 @@ public:
     }
 #endif
 
-    static std::string precisionFormat(Precision precision, double value);
+    FAKER_CXX_EXPORT static std::string precisionFormat(Precision precision, double value);
 
-    static std::string
+    FAKER_CXX_EXPORT static std::string
     fillTokenValues(const std::string& format,
                     std::unordered_map<std::string, std::function<std::string()>> tokenValueGenerators);
 
-    static std::string
+    FAKER_CXX_EXPORT static std::string
     fillTokenValues(const std::string& format,
                     std::unordered_map<std::string_view, std::function<std::string_view()>> tokenValueGenerators);
 };

--- a/src/common/LuhnCheck.h
+++ b/src/common/LuhnCheck.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include "faker-cxx/Export.h"
 
 namespace faker
 {
@@ -15,7 +16,7 @@ public:
      * @return The luhn checksum value for the given value.
      *
      */
-    static int luhnCheckSum(const std::string& inputString);
+    FAKER_CXX_EXPORT static int luhnCheckSum(const std::string& inputString);
 
     /**
      * @brief Checks that the given string passes the luhn algorithm.
@@ -25,7 +26,7 @@ public:
      * @return Is the string pass the check or not.
      *
      */
-    static bool luhnCheck(const std::string& inputString);
+    FAKER_CXX_EXPORT static bool luhnCheck(const std::string& inputString);
 
     /**
      * @brief Returns the luhn check value for the given string.
@@ -36,6 +37,6 @@ public:
      * @return the luhn check value for the given string.
      *
      */
-    static int luhnCheckValue(const std::string& inputString);
+    FAKER_CXX_EXPORT static int luhnCheckValue(const std::string& inputString);
 };
 }

--- a/src/common/StringHelper.h
+++ b/src/common/StringHelper.h
@@ -2,18 +2,19 @@
 
 #include <string>
 #include <vector>
+#include "faker-cxx/Export.h"
 
 namespace faker
 {
 class StringHelper
 {
 public:
-    static std::vector<std::string> split(const std::string& data, const std::string& separator = " ");
-    static std::string joinString(const std::vector<std::string>& data, const std::string& separator = " ");
-    static std::string join(const std::vector<std::string_view>& data, const std::string& separator = " ");
-    static std::string repeat(const std::string& data, int repetition);
-    static std::string toLower(const std::string& data);
-    static bool isPunctuation(char c);
-    static std::string removePunctuation(const std::string& word);
+    FAKER_CXX_EXPORT static std::vector<std::string> split(const std::string& data, const std::string& separator = " ");
+    FAKER_CXX_EXPORT static std::string joinString(const std::vector<std::string>& data, const std::string& separator = " ");
+    FAKER_CXX_EXPORT static std::string join(const std::vector<std::string_view>& data, const std::string& separator = " ");
+    FAKER_CXX_EXPORT static std::string repeat(const std::string& data, int repetition);
+    FAKER_CXX_EXPORT static std::string toLower(const std::string& data);
+    FAKER_CXX_EXPORT static bool isPunctuation(char c);
+    FAKER_CXX_EXPORT static std::string removePunctuation(const std::string& word);
 };
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,5 +79,7 @@ else ()
 endif ()
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME} WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+set_tests_properties(${PROJECT_NAME} PROPERTIES ENVIRONMENT_MODIFICATION
+                     "PATH=path_list_prepend:$<$<BOOL:${WIN32}>:$<TARGET_FILE_DIR:faker-cxx>>")
 
 target_code_coverage(${PROJECT_NAME} ALL)


### PR DESCRIPTION
- Added a new entry in the CI to build both static and shared in CI (Linux and Windows only)
- Export symbols using GenerateExportHeader to faker-cxx/Export.h
- Added export define for public methods
- Update contribution guide using new presets names
- Update CMake presets with new suffix: -static -shared
- Adjust ctest to load .dll file when running tests
- Validate project installation in CI using CMake install command

close #753