### PR TITLE
ci: Skip when changing markdown only

### DIFF
--- a/.github/workflows/linux-clang-build.yml
+++ b/.github/workflows/linux-clang-build.yml
@@ -10,6 +10,10 @@ on:
       - 'LICENSE'
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   build:

--- a/.github/workflows/linux-gxx-build.yml
+++ b/.github/workflows/linux-gxx-build.yml
@@ -10,6 +10,10 @@ on:
       - 'LICENSE'
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   build:

--- a/.github/workflows/linux-static-analysis.yml
+++ b/.github/workflows/linux-static-analysis.yml
@@ -10,6 +10,10 @@ on:
       - 'LICENSE'
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   build_project:

--- a/.github/workflows/macos-clang-build.yml
+++ b/.github/workflows/macos-clang-build.yml
@@ -10,7 +10,10 @@ on:
       - 'LICENSE'
   workflow_dispatch:
   pull_request:
-
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   build:

--- a/.github/workflows/windows-msvc-build.yml
+++ b/.github/workflows/windows-msvc-build.yml
@@ -11,6 +11,10 @@ on:
       - 'LICENSE'
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   build:


### PR DESCRIPTION
Hello!

This PR avoids running the CI when touching markdown files, LICENSE or anything the docs/ folder.

The current state in main branch is using a rule to avoid building only when pushing, not for pull requests. In order to apply same rule, we need to duplicate the [paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)


closes 643
