### PR TITLE
docs: Update README with how to install faker-cxx pre-built library using Conan

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ To build the library with Conan, follow the steps below:
     cmake --build --preset=conan-release
     ```
 
+## Installing the library with [Conan](https://conan.io/)
+
+You can install pre-built binaries for faker-cxx or build it from source using Conan. Use the following command:
+
+```bash
+conan install --requires="faker-cxx/[*]" --build=missing
+```
+
+The faker-cxx Conan recipe is kept up to date by Conan maintainers and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/conan-io/conan-center-index) on the ConanCenterIndex repository.
+
 ## ✨ Contributing
 
 We would love it if you contributed to Faker C++! 🚀


### PR DESCRIPTION
The PR https://github.com/conan-io/conan-center-index/pull/24018 has been merged and now Faker-cxx is listed in Conan Center. Users can install a pre-built library faker-cxx from there (or build from souce)

The recipe is available here:

https://github.com/conan-io/conan-center-index/blob/master/recipes/faker-cxx/all/conanfile.py

Packages are hosted by JFrog's Artifactory instance and maintained by Conan team. 

The Conan Center search page is outdated, but as soon as it gets updated, faker-cxx should be listed there too: https://conan.io/center/recipes?value=faker-cxx

Meanwhile, is possible to find the package via CLI:

    conan search -r conancenter faker-cxx