### PR TITLE
test: enhance code coverage of format helper module by adding additional testcases

### DIFF
--- a/tests/common/format_helper_test.cpp
+++ b/tests/common/format_helper_test.cpp
@@ -49,3 +49,32 @@ TEST_F(FormatHelperTest, shouldFormat)
     EXPECT_EQ(format("{} {}", "Hello", "World"), "Hello World");
     EXPECT_EQ(format("{0} {1}", "Hello", "World"), "Hello World");
 }
+
+TEST_F(FormatHelperTest, ThrowsExceptionForMissingTokenGenerator)
+{
+    const auto format = "{existing} {missing}";
+    const auto dataGeneratorsMapping = std::unordered_map<std::string, std::function<std::string()>>{
+        {"existing", []() { return "value"; }}
+    };
+
+    try {
+        fillTokenValues(format, dataGeneratorsMapping);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e) {
+        EXPECT_STREQ(e.what(), "Generator not found for token missing.");
+    }
+}
+
+TEST_F(FormatHelperTest, PrecisionFormat)
+{
+    EXPECT_EQ(precisionFormat(Precision::ZeroDp, 3.14159), "3");
+    EXPECT_EQ(precisionFormat(Precision::OneDp, 3.14159), "3.1");
+    EXPECT_EQ(precisionFormat(Precision::FiveDp, 3.14159), "3.14159");
+    EXPECT_EQ(precisionFormat(Precision::SevenDp, 3.14159), "3.1415900");
+}
+
+TEST_F(FormatHelperTest, ThrowsForInvalidPrecision)
+{
+    EXPECT_THROW(precisionFormat(static_cast<Precision>(999), 3.14159), std::invalid_argument);
+}

--- a/tests/modules/word/word_test.cpp
+++ b/tests/modules/word/word_test.cpp
@@ -219,3 +219,38 @@ TEST_F(WordTest, shouldGenerateWords)
     ASSERT_TRUE(std::ranges::all_of(separatedWords, [](const std::string& separatedWord)
                                     { return std::ranges::find(_allWords, separatedWord) != _allWords.end(); }));
 }
+
+TEST_F(WordTest, shouldReturnRandomElementWhenExactLengthNotFound)
+{
+    const unsigned int existingLength = 5;
+    
+    std::vector<std::string_view> matchingAdjectives;
+    for (const auto& adj : _adjectives_sorted) {
+        if (adj.size() == existingLength) {
+            matchingAdjectives.push_back(adj);
+        }
+    }
+    
+    const auto generatedAdjective = adjective(existingLength + 1);
+    
+    ASSERT_TRUE(std::ranges::find(_adjectives_sorted, generatedAdjective) != _adjectives_sorted.end());
+    ASSERT_TRUE(std::ranges::find(matchingAdjectives, generatedAdjective) == matchingAdjectives.end());
+}
+
+TEST_F(WordTest, shouldReturnEmptyStringForZeroWords)
+{
+    const auto result = words(0);
+    ASSERT_TRUE(result.empty());
+}
+
+TEST_F(WordTest, shouldGenerateLargeNumberOfWords)
+{
+    const unsigned int largeWordCount = 300;
+    const auto generatedWords = words(largeWordCount);
+    const auto separatedWords = common::split(generatedWords, " ");
+    
+    ASSERT_EQ(separatedWords.size(), largeWordCount);
+    for (const auto& word : separatedWords) {
+        ASSERT_TRUE(std::ranges::find(_allWords, word) != _allWords.end());
+    }
+}


### PR DESCRIPTION
This pull request addresses issue #781 by adding additional test cases for the `format_helper` module, to improve overall code coverage.

- The additions are based on the latest code coverage report, which can be found [here](https://app.codecov.io/github/cieslarmichal/faker-cxx/blob/main/src%2Fcommon%2FFormatHelper.cpp), I've tried targeting previously uncovered lines in `format_helper.cpp`