### PR TITLE
refactor: function name changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file
 
 * removed `location.county` method
 * renamed all include files from `CamelCase` to `snake_case`
+* changed function name from `number` (by format) to `phoneNumberByFormat` in phone module
+* changed function name from `number` (by country) to `phoneNumberByCountry` in phone module
 
 ## v2.0.0 (27.06.2024)
 
@@ -40,8 +42,6 @@ All notable changes to this project will be documented in this file
 * changed function name from `vehicle` to `vehicleName` in vehicle module
 * changed function name from `timezone` to `timezoneRandom` in date module
 * deleted function `commonFileType` from `System` module, use `system.fileType` instead
-* changed function name from `number` (by format) to `phoneNumberByFormat` in phone module
-* changed function name from `number` (by country) to `phoneNumberByCountry` in phone module
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this project will be documented in this file
 * changed function name from `vehicle` to `vehicleName` in vehicle module
 * changed function name from `timezone` to `timezoneRandom` in date module
 * deleted function `commonFileType` from `System` module, use `system.fileType` instead
+* changed function name from `number` (by format) to `phoneNumberByFormat` in phone module
+* changed function name from `number` (by country) to `phoneNumberByCountry` in phone module
 
 ### Features
 

--- a/include/faker-cxx/phone.h
+++ b/include/faker-cxx/phone.h
@@ -17,12 +17,12 @@ enum class PhoneNumberCountryFormat;
      * @returns Random phone number.
      *
      * @code
-     * faker::phone::number() // "961-770-7727"
-     * faker::phone::number("501-###-###") // "501-039-841"
-     * faker::phone::number("+48 91 ### ## ##") // "+48 91 463 61 70"
+     * faker::phone::phoneNumberByFormat() // "961-770-7727"
+     * faker::phone::phoneNumberByFormat("501-###-###") // "501-039-841"
+     * faker::phone::phoneNumberByFormat("+48 91 ### ## ##") // "+48 91 463 61 70"
      * @endcode
      */
-    FAKER_CXX_EXPORT std::string number(std::optional<std::string> = std::nullopt);
+    FAKER_CXX_EXPORT std::string phoneNumberByFormat(std::optional<std::string> = std::nullopt);
 
     /**
      * @brief Returns a random phone platform.
@@ -68,7 +68,7 @@ enum class PhoneNumberCountryFormat;
      * faker::phone::number(PhoneNumberCountryFormat::Usa) // "+1 (395) 714-1494"
      * @endcode
      */
-    FAKER_CXX_EXPORT std::string number(PhoneNumberCountryFormat format);
+    FAKER_CXX_EXPORT std::string phoneNumberByCountry(PhoneNumberCountryFormat format);
 
     /**
      * @brief Returns IMEI number.

--- a/src/modules/phone.cpp
+++ b/src/modules/phone.cpp
@@ -13,7 +13,7 @@ namespace faker::phone
 {
 std::unordered_map<PhoneNumberCountryFormat, std::string> phoneNumberFormatMap = createPhoneNumberFormatMap();
 
-std::string number(std::optional<std::string> format)
+std::string phoneNumberByFormat(std::optional<std::string> format)
 {
     std::string selectedFormat;
 
@@ -29,7 +29,7 @@ std::string number(std::optional<std::string> format)
     return helper::replaceSymbolWithNumber(selectedFormat);
 }
 
-std::string number(PhoneNumberCountryFormat format)
+std::string phoneNumberByCountry(PhoneNumberCountryFormat format)
 {
     std::string countryFormat = phoneNumberFormatMap.at(format);
 

--- a/tests/modules/phone_test.cpp
+++ b/tests/modules/phone_test.cpp
@@ -25,7 +25,7 @@ protected:
 
 TEST_F(PhoneTest, NumberWithNoFormat)
 {
-    const auto phoneNumber = number();
+    const auto phoneNumber = phoneNumberByFormat();
 
     ASSERT_TRUE(isStringNumericWithSpecialChars(phoneNumber));
 }
@@ -33,24 +33,32 @@ TEST_F(PhoneTest, NumberWithNoFormat)
 TEST_F(PhoneTest, NumberWithFormat)
 {
     auto format = "501-###-###";
-    auto phoneNumber = number(format);
+    auto phoneNumber = phoneNumberByFormat(format);
     ASSERT_NE(phoneNumber, format);
     ASSERT_TRUE(isStringNumericWithSpecialChars(phoneNumber));
 
     format = "+48 91 ### ## ##";
-    phoneNumber = number(format);
+    phoneNumber = phoneNumberByFormat(format);
     ASSERT_NE(phoneNumber, format);
     ASSERT_TRUE(isStringNumericWithSpecialChars(phoneNumber));
 
     format = "+376 (###) ###-####";
-    phoneNumber = number(format);
+    phoneNumber = phoneNumberByFormat(format);
     ASSERT_NE(phoneNumber, format);
     ASSERT_TRUE(isStringNumericWithSpecialChars(phoneNumber));
 
     format = "+376 (!!!) !!!-!!!!";
-    phoneNumber = number(format);
+    phoneNumber = phoneNumberByFormat(format);
     ASSERT_NE(phoneNumber, format);
     ASSERT_TRUE(isStringNumericWithSpecialChars(phoneNumber));
+}
+
+TEST_F(PhoneTest, NumberWithCountryFormat)
+{
+    const auto generatedPhoneNumber = phoneNumberByCountry(PhoneNumberCountryFormat::Zimbabwe);
+
+    EXPECT_FALSE(generatedPhoneNumber.empty());
+    ASSERT_TRUE(isStringNumericWithSpecialChars(generatedPhoneNumber));
 }
 
 TEST_F(PhoneTest, IMEIGeneration)
@@ -61,14 +69,6 @@ TEST_F(PhoneTest, IMEIGeneration)
 
     ASSERT_EQ(generatedImei.length(), 15);
     ASSERT_TRUE(isStringNumericWithSpecialChars(generatedImei));
-}
-
-TEST_F(PhoneTest, NumberFormatTest)
-{
-    const auto generatedPhoneNumber = number(PhoneNumberCountryFormat::Zimbabwe);
-
-    EXPECT_FALSE(generatedPhoneNumber.empty());
-    ASSERT_TRUE(isStringNumericWithSpecialChars(generatedPhoneNumber));
 }
 
 TEST_F(PhoneTest, PlatformGeneration)


### PR DESCRIPTION
* changed function name from `number` (by format) to `phoneNumberByFormat` in phone module
* changed function name from `number` (by country) to `phoneNumberByCountry` in phone module
* modified test case for `phoneNumberByCountry` function

Fixes: #823
