### PR TITLE
fix: Made range arrayFormat overload more elegant + minor fixes

### DIFF
--- a/include/faker-cxx/helper.h
+++ b/include/faker-cxx/helper.h
@@ -49,7 +49,7 @@ T arrayElement(const std::array<T, N>& data)
     return data[index];
 }
 
-template <typename It>
+template <std::input_iterator It>
 auto arrayElement(It start, It end) -> decltype(*::std::declval<It>())
 {
     auto size = static_cast<size_t>(end - start);
@@ -61,7 +61,7 @@ auto arrayElement(It start, It end) -> decltype(*::std::declval<It>())
 
     const std::integral auto index = number::integer<size_t>(size - 1);
 
-    return start[index];
+    return *(start + static_cast<std::iter_difference_t<It>>(index));
 }
 
 /**

--- a/src/modules/datatype.cpp
+++ b/src/modules/datatype.cpp
@@ -13,21 +13,19 @@ bool boolean()
 
 bool boolean(double probability)
 {
-    if (probability != nan(""))
+    if (!std::isnan(probability))
     {
-        double prob = probability;
-
-        if (prob <= double(0.))
+        if (probability <= double(0))
         {
             return false;
         }
 
-        if (prob >= double(1.))
+        if (probability >= double(1))
         {
             return true;
         }
 
-        return double(number::decimal(0., 1.)) < prob;
+        return number::decimal(0., 1.) < probability;
     }
 
     return number::decimal(0., 1.) < 0.5;


### PR DESCRIPTION
Running on latest GCC version and `ubuntu 22.04` I was getting conversion warnings from `arrayFormat(start, end)` overload specifically when used with `sortedSizeArrayElement` in `word_test.cpp`

Primary Warnings thrown:
In instantiation of function template specialization 'faker::word::sortedSizeArrayElement<__gnu_cxx::__normal_iterator<std::basic_string<char> *, std::vector<std::basic_string<char>>>>' /home/eric/github/faker-cxx/include/faker-cxx/helper.h:64:18: warning: implicit conversion changes signedness: 'unsigned long const' to '__gnu_cxx::__normal_iterator<std::basic_string<char> *, std::vector<std::basic_string<char>>>::difference_type' (aka 'long')

Fixed `arrayFormat` to enforce `input_iterator` concept in templates and fixed implicit conversion in index return of the function.
Cleaned up `boolean(probability)` of `datatype.cpp`
- Originally checked ifnan through  `if (probability != nan(""))` now uses `std::isnan` function