### PR TITLE
fix: arrayElement overloads failing with non-arithmetic iterators

### DIFF
--- a/include/faker-cxx/helper.h
+++ b/include/faker-cxx/helper.h
@@ -49,8 +49,8 @@ T arrayElement(const std::array<T, N>& data)
     return data[index];
 }
 
-template <std::input_iterator It>
-auto arrayElement(It start, It end) -> decltype(*::std::declval<It>())
+template <std::random_access_iterator It>
+auto arrayElement(It start, It end) -> It::range_difference_t
 {
     auto size = static_cast<size_t>(end - start);
 
@@ -61,7 +61,27 @@ auto arrayElement(It start, It end) -> decltype(*::std::declval<It>())
 
     const std::integral auto index = number::integer<size_t>(size - 1);
 
-    return *(start + static_cast<std::iter_difference_t<It>>(index));
+    return start[index];
+}
+
+template <std::input_iterator It>
+auto arrayElement(It start, It end)
+{
+    auto size = std::distance(start, end);
+
+    if (size == 0)
+    {
+        throw std::invalid_argument{"Range [start,end) is empty."};
+    }
+
+    const std::integral auto index = number::integer<size_t>(static_cast<unsigned long>(size - 1));
+
+    std::input_iterator auto dummyIterator = start;
+
+    for (size_t i = 0; i < index; i++)
+        dummyIterator++;
+
+    return *dummyIterator;
 }
 
 /**

--- a/include/faker-cxx/word.h
+++ b/include/faker-cxx/word.h
@@ -4,8 +4,8 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include "faker-cxx/export.h"
 
+#include "faker-cxx/export.h"
 #include "faker-cxx/helper.h"
 
 namespace faker::word
@@ -144,8 +144,9 @@ FAKER_CXX_EXPORT std::string_view preposition(std::optional<unsigned> length = s
  */
 FAKER_CXX_EXPORT std::string_view verb(std::optional<unsigned> length = std::nullopt);
 
-template <typename It>
-auto sortedSizeArrayElement(std::optional<unsigned int> length, It start, It end) -> decltype(*std::declval<It>())
+template <std::input_iterator It>
+auto sortedSizeArrayElement(std::optional<unsigned int> length, It start, It end) ->
+    typename std::iterator_traits<It>::value_type
 {
     if (!length)
     {


### PR DESCRIPTION
`arrayElement(start, end)` overloads would fail when being used with bidrectional iterators or basically anything that wasnt a `random_access_iterator`, so I added overloads for both `random_access_iterator`'s and every other form.
Since random_access supports arithmetic we can just access index, but since every other iterator doesn't support we need to hand roll to the index. 

Even before I rewrote the function yesterday it still would've failed on `list` containers or non-random_access iterators. 