### PR TITLE
refactor: Refactored all of randomElement related functions and iterators to use ranges instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ option(BUILD_EXAMPLES "Build examples" OFF)
 option(BUILD_TESTING "Build tests" ON)
 option(CODE_COVERAGE "Build faker-cxx with coverage support" OFF)
 
+SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if (MSVC)
     set(CMAKE_REQUIRED_FLAGS /std:c++20)
 else()

--- a/include/faker-cxx/helper.h
+++ b/include/faker-cxx/helper.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <initializer_list>
 #include <numeric>
 #include <random>
 #include <vector>
@@ -75,32 +74,6 @@ auto randomElement(Range&& range)
     }
 
     return result;
-}
-
-/**
- * @brief Get a random element from an initializer list.
- *
- * @tparam T an element type of the initializer list.
-    while (start != end) {
- * @param data initializer list of elements.
- *
- * @return T a random element from the initializer list.
- *
- * @code
- * faker::helper::randomElement<std::string>(std::initializer_list<std::string>{{"hello"}, {"world"}}) // "hello"
- * @endcode
- */
-template <class T>
-T randomElement(const std::initializer_list<T>& data)
-{
-    if (data.size() == 0)
-    {
-        throw std::invalid_argument{"Data is empty."};
-    }
-
-    const auto index = number::integer<size_t>(data.size() - 1);
-
-    return *(data.begin() + index);
 }
 
 /**

--- a/include/faker-cxx/helper.h
+++ b/include/faker-cxx/helper.h
@@ -4,7 +4,6 @@
 #include <numeric>
 #include <span>
 #include <vector>
-#include <iostream>
 
 #include "number.h"
 
@@ -64,7 +63,6 @@ auto randomElement(It start, It end)
     return start[index];
 }
 
-
 template <std::forward_iterator It>
 auto& randomElement(It start, It end)
 {
@@ -80,9 +78,11 @@ auto& randomElement(It start, It end)
     ++start;
     size_t count = 1;
 
-    while (start != end) {
-        std::uniform_int_distribution<size_t> distrib(0, count - 1);
-        if (distrib(gen) == 0) {
+    while (start != end)
+    {
+        std::uniform_int_distribution<size_t> distrib(0, count);
+        if (distrib(gen) == 0)
+        {
             result = *start;
         }
         ++start;
@@ -107,9 +107,11 @@ auto randomElement(It start, It end)
     ++start;
     size_t count = 1;
 
-    while (start != end) {
+    while (start != end)
+    {
         std::uniform_int_distribution<size_t> distrib(0, count);
-        if (distrib(gen) == 0) {
+        if (distrib(gen) == 0)
+        {
             result = std::move(*start);
         }
         ++start;

--- a/include/faker-cxx/word.h
+++ b/include/faker-cxx/word.h
@@ -144,22 +144,24 @@ FAKER_CXX_EXPORT std::string_view preposition(std::optional<unsigned> length = s
  */
 FAKER_CXX_EXPORT std::string_view verb(std::optional<unsigned> length = std::nullopt);
 
-template <std::input_iterator It>
-auto sortedSizeRandomElement(std::optional<unsigned int> length, It start, It end) ->
-    typename std::iterator_traits<It>::value_type
+template <faker::helper::input_range_with_faster_size_compute_than_linear_rng Range>
+auto sortedSizeRandomElement(std::optional<unsigned int> length, Range&& range) -> decltype(auto)
 {
     if (!length)
     {
-        return helper::randomElement(start, end);
+        return helper::randomElement(range);
     }
 
     size_t length_64 = *length;
+    auto start = range.begin();
+    auto end = range.end();
+
     auto lower_it = ::std::lower_bound(start, end, length_64,
                                        [](const auto& lhs, const auto& value) { return lhs.size() < value; });
 
     if (lower_it == end)
     {
-        return helper::randomElement(start, end);
+        return helper::randomElement(range);
     }
 
     if (lower_it->size() != length)
@@ -177,6 +179,6 @@ auto sortedSizeRandomElement(std::optional<unsigned int> length, It start, It en
         }
     }
 
-    return helper::randomElement(lower_it, upper_it);
+    return helper::randomElement(std::ranges::subrange(lower_it, upper_it));
 }
 }

--- a/include/faker-cxx/word.h
+++ b/include/faker-cxx/word.h
@@ -144,7 +144,20 @@ FAKER_CXX_EXPORT std::string_view preposition(std::optional<unsigned> length = s
  */
 FAKER_CXX_EXPORT std::string_view verb(std::optional<unsigned> length = std::nullopt);
 
-template <faker::helper::input_range_with_faster_size_compute_than_linear_rng Range>
+/**
+ * @brief Returns random element of length
+ *
+ * @param length The length of the elements to be picked from
+ *
+ * @ range The range of elements
+ *
+ * @returns An element of the range value type
+ *
+ * @code
+ * faker::word::sortedSizeRandomElement(3, {"hi, "hello", "hey"}) // "hey" - Since "hey" is the only element of length 3
+ * @endcode
+ */
+template <std::ranges::range Range>
 auto sortedSizeRandomElement(std::optional<unsigned int> length, Range&& range) -> decltype(auto)
 {
     if (!length)

--- a/src/common/algo_helper.h
+++ b/src/common/algo_helper.h
@@ -2,11 +2,11 @@
 
 #include <algorithm>
 #include <functional>
+#include <iterator>
 #include <random>
 #include <set>
 #include <stdexcept>
 #include <string>
-#include <iterator>
 
 #include "faker-cxx/datatype.h"
 #include "faker-cxx/export.h"
@@ -44,9 +44,10 @@ static T::key_type objectKey(const T& object)
     std::vector<typename T::key_type> keys;
     keys.reserve(object.size());
 
-    std::transform(object.begin(), object.end(), std::back_inserter(keys), [](const auto& entry) { return entry.first; });
+    std::transform(object.begin(), object.end(), std::back_inserter(keys),
+                   [](const auto& entry) { return entry.first; });
 
-    return randomElement<typename T::key_type>(keys);
+    return randomElement(keys);
 }
 
 template <typename TResult>

--- a/src/modules/airline.cpp
+++ b/src/modules/airline.cpp
@@ -33,7 +33,7 @@ Airport airport()
 std::string seat(AircraftType aircraftType)
 {
     return std::to_string(number::integer(1, aircraftTypeMaxRows.at(aircraftType))) +
-           helper::randomElement<char>(aircraftTypeSeatLetters.at(aircraftType));
+           helper::randomElement(aircraftTypeSeatLetters.at(aircraftType));
 }
 
 std::string recordLocator(bool allowNumerics)

--- a/src/modules/internet.cpp
+++ b/src/modules/internet.cpp
@@ -100,8 +100,7 @@ std::string username(std::optional<std::string> firstName, std::optional<std::st
         break;
     case 2:
         username = common::format("{}{}{}", lastNameLower,
-                                  helper::randomElement(std::vector<std::string>{".", "_", ""}),
-                                  firstNameLower);
+                                  helper::randomElement(std::vector<std::string>{".", "_", ""}), firstNameLower);
         break;
     }
 
@@ -149,7 +148,7 @@ std::string password(int length, const PasswordOptions& options)
 
     for (int i = 0; i < length; ++i)
     {
-        password += helper::randomElement<char>(characters);
+        password += helper::randomElement(characters);
     }
 
     return password;

--- a/src/modules/science.cpp
+++ b/src/modules/science.cpp
@@ -20,7 +20,7 @@ Unit unit()
     units.insert(units.end(), currentUnits.begin(), currentUnits.end());
     units.insert(units.end(), temperatureUnits.begin(), temperatureUnits.end());
 
-    return helper::randomElement<Unit>(units);
+    return helper::randomElement(units);
 }
 
 Unit distanceUnit()

--- a/src/modules/string.cpp
+++ b/src/modules/string.cpp
@@ -155,7 +155,7 @@ std::string fromCharacters(const std::string& characters, unsigned int length)
 
     for (unsigned i = 0; i < length; i++)
     {
-        result += helper::randomElement<char>(characters);
+        result += helper::randomElement(characters);
     }
 
     return result;
@@ -196,7 +196,7 @@ std::string alpha(unsigned length, StringCasing casing, const std::string& exclu
 
     for (unsigned i = 0; i < length; i++)
     {
-        alpha += helper::randomElement<char>(targetCharacters);
+        alpha += helper::randomElement(targetCharacters);
     }
 
     return alpha;
@@ -232,7 +232,7 @@ std::string alphanumeric(unsigned int length, StringCasing casing, const std::st
 
     for (unsigned i = 0; i < length; i++)
     {
-        alphanumeric += helper::randomElement<char>(targetCharacters);
+        alphanumeric += helper::randomElement(targetCharacters);
     }
 
     return alphanumeric;
@@ -263,11 +263,11 @@ std::string numeric(unsigned int length, bool allowLeadingZeros)
     {
         if (i == 0 && allowLeadingZeros)
         {
-            alphanumericStr.push_back(helper::randomElement<char>(numericCharacters));
+            alphanumericStr.push_back(helper::randomElement(numericCharacters));
         }
         else
         {
-            alphanumericStr.push_back(helper::randomElement<char>(numericCharactersWithoutZero));
+            alphanumericStr.push_back(helper::randomElement(numericCharactersWithoutZero));
         }
     }
 
@@ -321,7 +321,7 @@ std::string hexadecimal(unsigned int length, HexCasing casing, HexPrefix prefix)
 
     for (unsigned i = 0; i < length; i++)
     {
-        hexadecimal += helper::randomElement<char>(hexadecimalCharacters);
+        hexadecimal += helper::randomElement(hexadecimalCharacters);
     }
 
     return hexadecimal;

--- a/src/modules/system.cpp
+++ b/src/modules/system.cpp
@@ -267,6 +267,6 @@ std::string cron(const CronOptions& options)
                                                        "@reboot",   "@weekly", "@yearly"};
 
     return (!includeNonStandard || datatype::boolean(0)) ? standardExpression :
-                                                           helper::randomElement<std::string>(nonStandardExpressions);
+                                                           helper::randomElement(nonStandardExpressions);
 }
 }

--- a/src/modules/word.cpp
+++ b/src/modules/word.cpp
@@ -1,16 +1,17 @@
+#include "faker-cxx/word.h"
+
 #include <array>
 #include <optional>
 #include <string>
 #include <string_view>
 
-#include "faker-cxx/word.h"
 #include "word_data.h"
 
 namespace faker::word
 {
 std::string_view sample(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _allWords.cbegin(), _allWords.cend());
+    return sortedSizeRandomElement(length, _allWords);
 }
 
 std::string words(unsigned numberOfWords)
@@ -64,36 +65,36 @@ std::string words(unsigned numberOfWords)
 
 std::string_view adjective(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _adjectives_sorted.cbegin(), _adjectives_sorted.cend());
+    return sortedSizeRandomElement(length, _adjectives_sorted);
 }
 
 std::string_view adverb(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _adverbs_sorted.cbegin(), _adverbs_sorted.cend());
+    return sortedSizeRandomElement(length, _adverbs_sorted);
 }
 
 std::string_view conjunction(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _conjunctions_sorted.cbegin(), _conjunctions_sorted.cend());
+    return sortedSizeRandomElement(length, _conjunctions_sorted);
 }
 
 std::string_view interjection(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _interjections_sorted.cbegin(), _interjections_sorted.cend());
+    return sortedSizeRandomElement(length, _interjections_sorted);
 }
 
 std::string_view noun(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _nouns_sorted.cbegin(), _nouns_sorted.cend());
+    return sortedSizeRandomElement(length, _nouns_sorted);
 }
 
 std::string_view preposition(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _prepositions_sorted.cbegin(), _prepositions_sorted.cend());
+    return sortedSizeRandomElement(length, _prepositions_sorted);
 }
 
 std::string_view verb(std::optional<unsigned int> length)
 {
-    return sortedSizeRandomElement(length, _verbs_sorted.cbegin(), _verbs_sorted.cend());
+    return sortedSizeRandomElement(length, _verbs_sorted);
 }
 }

--- a/tests/modules/word_test.cpp
+++ b/tests/modules/word_test.cpp
@@ -1,5 +1,3 @@
-#include "faker-cxx/word.h"
-
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -7,6 +5,7 @@
 #include "gtest/gtest.h"
 
 #include "common/string_helper.h"
+#include "faker-cxx/word.h"
 #include "word_data.h"
 
 using namespace faker::word;
@@ -223,16 +222,18 @@ TEST_F(WordTest, shouldGenerateWords)
 TEST_F(WordTest, shouldReturnRandomElementWhenExactLengthNotFound)
 {
     const unsigned int existingLength = 5;
-    
+
     std::vector<std::string_view> matchingAdjectives;
-    for (const auto& adj : _adjectives_sorted) {
-        if (adj.size() == existingLength) {
+    for (const auto& adj : _adjectives_sorted)
+    {
+        if (adj.size() == existingLength)
+        {
             matchingAdjectives.push_back(adj);
         }
     }
-    
+
     const auto generatedAdjective = adjective(existingLength + 1);
-    
+
     ASSERT_TRUE(std::ranges::find(_adjectives_sorted, generatedAdjective) != _adjectives_sorted.end());
     ASSERT_TRUE(std::ranges::find(matchingAdjectives, generatedAdjective) == matchingAdjectives.end());
 }
@@ -248,9 +249,10 @@ TEST_F(WordTest, shouldGenerateLargeNumberOfWords)
     const unsigned int largeWordCount = 300;
     const auto generatedWords = words(largeWordCount);
     const auto separatedWords = common::split(generatedWords, " ");
-    
+
     ASSERT_EQ(separatedWords.size(), largeWordCount);
-    for (const auto& word : separatedWords) {
+    for (const auto& word : separatedWords)
+    {
         ASSERT_TRUE(std::ranges::find(_allWords, word) != _allWords.end());
     }
 }
@@ -260,7 +262,7 @@ TEST_F(WordTest, returnsRandomElementWhenAllElementsLessthanGivenLength)
     std::vector<std::string> words = {"one", "three", "five"};
     std::optional<unsigned int> length = 6;
 
-    auto result = sortedSizeRandomElement(length, words.begin(), words.end());
+    auto result = sortedSizeRandomElement(length, words);
 
     ASSERT_TRUE(result == "one" || result == "three" || result == "five");
 }
@@ -270,7 +272,7 @@ TEST_F(WordTest, returnsFirstElementWhenNoLengthMatch)
     std::vector<std::string> words = {"one", "three", "five"};
     std::optional<unsigned int> length = 4;
 
-    auto result = sortedSizeRandomElement(length, words.begin(), words.end());
+    auto result = sortedSizeRandomElement(length, words);
 
     ASSERT_TRUE(result == "three");
 }


### PR DESCRIPTION
With all of these functions using ranges instead of iterators, all you have to do is just pass the container straight since these cover all overloads.

Instead of using a pair of iterators you can use `ranges::subrange(start, end)` instead etc
These algos are also a lot more optimized and follow the best practices.

The first algo which is multipass is specifically for random_accsess and forward / sized ranges. Every other type of range that is basic like input_range uses a single pass approach.