### PR TITLE
feat: create e-sport module (#768)

### DIFF
--- a/include/faker-cxx/esport.h
+++ b/include/faker-cxx/esport.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <string_view>
+
+#include "faker-cxx/export.h"
+
+namespace faker::esport
+{
+
+/**
+ * @brief Returns a random player name.
+ *
+ * @return Player name.
+ *
+ * @code
+ * faker::esport::player() // "Faker"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view player();
+
+/**
+ * @brief Returns a random esport team.
+ *
+ * @return Esport team.
+ *
+ * @code
+ * faker::esport::team() // "Karmine Corp"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view team();
+
+/**
+ * @brief Returns a random esport league.
+ *
+ * @return Esport League.
+ *
+ * @code
+ * faker::esport::league() // "LEC"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view league();
+
+/**
+ * @brief Returns a random esport event.
+ *
+ * @return Esport Event.
+ *
+ * @code
+ * faker::esport::event() // "Faker"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view event();
+
+/**
+ * @brief Returns a random competitive video game.
+ *
+ * @return Competitive video game.
+ *
+ * @code
+ * faker::esport::game() // "Rocket League"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view game();
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ set(FAKER_SOURCES
     modules/plant.cpp
     modules/science.cpp
     modules/sport.cpp
+    modules/esport.cpp
     modules/string.cpp
     modules/system.cpp
     modules/vehicle.cpp
@@ -77,6 +78,7 @@ set(FAKER_HEADERS
     modules/phone_data.h
     modules/color_data.h
     modules/lorem_data.h
+    modules/esport_data.h
 )
 
 target_sources(${CMAKE_PROJECT_NAME} PRIVATE ${FAKER_SOURCES} ${FAKER_HEADERS})

--- a/src/modules/esport.cpp
+++ b/src/modules/esport.cpp
@@ -1,0 +1,35 @@
+#include "faker-cxx/esport.h"
+
+#include <string_view>
+
+#include "esport_data.h"
+#include "faker-cxx/helper.h"
+
+namespace faker::esport
+{
+std::string_view player()
+{
+    return helper::randomElement(players);
+}
+
+std::string_view team()
+{
+    return helper::randomElement(teams);
+}
+
+std::string_view league()
+{
+    return helper::randomElement(leagues);
+}
+
+std::string_view event()
+{
+    return helper::randomElement(events);
+}
+
+std::string_view game()
+{
+    return helper::randomElement(games);
+}
+
+}

--- a/src/modules/esport_data.h
+++ b/src/modules/esport_data.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace faker::esport
+{
+const auto players = std::to_array<std::string_view>(
+    {"Adam",    "Alvaro",  "Brokenblade", "Canna",     "Caps",       "Carzzy",    "Closer",    "Comp",   "Elyoya",
+     "Finn",    "Flakked", "Fresskowy",   "Hans Sama", "Humanoid",   "Hylissang", "Ice",       "IgNar",  "Irrelevant",
+     "Isma",    "Jackies", "Jankos",      "Juhan",     "Jun",        "Labrov",    "Larssen",   "Luon",   "Lyncas",
+     "Markoon", "Mikyx",   "Myrwn",       "Nisqy",     "Noah",       "Oscarinin", "Patrik",    "Photon", "Rahel",
+     "Razork",  "Sheo",    "Supa",        "Targamas",  "Th3Antonio", "Trymbi",    "Upset",     "Vetheo", "Vladi",
+     "Wunder",  "Yike",    "Zoelys",      "Zwyroo",    "nuc",        "Aiming",    "Andil",     "Bdd",    "BeryL",
+     "Bulldog", "Calix",   "Callme",      "Canyon",    "Casting",    "Chovy",     "Clear",     "Clozer", "Cuzz",
+     "DDoiV",   "Deft",    "Delight",     "DnDn",      "Doran",      "DuDu",      "Duro",      "Envyy",  "Execute",
+     "FATE",    "Faker",   "Fisher",      "Frog",      "GuGer",      "Gumayusi",  "Hena",      "Jiwoo",  "Karis",
+     "Kellin",  "Keria",   "Kiin",        "Kyeahoo",   "Leaper",     "Lehends",   "Lucid",     "Mihile", "Moham",
+     "Morgan",  "Oner",    "Paduck",      "Peanut",    "PerfecT",    "Peyz",      "Pleata",    "Pollu",  "Pullbae",
+     "Pyosik",  "Quantum", "Raptor",      "Rascal",    "Samver",     "SeTab",     "ShowMaker", "Sponge", "Sylvie",
+     "Teddy",   "Viper",   "Vital",       "YoungJae",  "Zeka",       "Zeus",      "kingen"});
+
+const auto teams = std::to_array<std::string_view>(
+    {"Team Liquid",      "G2 Esports", "OpTic Gaming", "Natus Vincere", "Astralis",    "NRG",
+     "7figures Esports", "HEROIC",     "Faze Clan",    "Fnatic",        "Virtus.pro",  "Ninjas in Pyjamas",
+     "CompLexity",       "TSM",        "BIG",          "Karmine Corp",  "Cloud9",      "Evil Geniuses",
+     "Team VItality",    "Mouz",       "100 Thieves",  "NaVi",          "Team Secret", "Vitality",
+     "Gambit Esports",   "BDS",        "Gentle Mates"});
+
+const auto leagues = std::to_array<std::string_view>(
+    {"LEC", "LPL", "LCK", "LCS NA", "LFL", "PUBG Mobile Super League", "VCT", "VCT GC", "F1 Esports Series",
+     "Overwatch League", "Superliga", "Prime League", "TCL", "Call of Duty League", "RLCS"});
+
+const auto events =
+    std::to_array<std::string_view>({"MSI", "EMEA Masters", "League of Legends World Championship", "EWC",
+                                     "The International", "Fortnite World Cup", "Six Invitational", "Capcom X Cup",
+                                     "VCT Masters"
+                                     "RLCS Major",
+                                     "IEM"});
+
+const auto games = std::to_array<std::string_view>({"Valorant", "League Of Legend", "Rocket League", "Fifa",
+                                                    "Overwatch", "CSGO", "Fortnite", "Dota 2",
+                                                    "Street Fighter,"
+                                                    "Apex Legends",
+                                                    "TFT", "PUBG", "Call of Duty"});
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(FAKER_UT_SOURCES
     modules/plant_test.cpp
     modules/science_test.cpp
     modules/sport_test.cpp
+    modules/esport_test.cpp
     modules/string_test.cpp
     modules/system_test.cpp
     modules/vehicle_test.cpp

--- a/tests/modules/esport_test.cpp
+++ b/tests/modules/esport_test.cpp
@@ -1,0 +1,55 @@
+#include <algorithm>
+#include <string_view>
+
+#include "gtest/gtest.h"
+
+#include "esport_data.h"
+#include "faker-cxx/esport.h"
+
+using namespace ::testing;
+using namespace faker::esport;
+
+class EsportTest : public Test
+{
+public:
+};
+
+TEST_F(EsportTest, shouldGeneratePlayer)
+{
+    const auto generatedPlayer = player();
+
+    ASSERT_TRUE(std::ranges::any_of(players, [generatedPlayer](const std::string_view& player)
+                                    { return generatedPlayer == player; }));
+}
+
+TEST_F(EsportTest, shouldGenerateTeam)
+{
+    const auto generatedTeam = team();
+
+    ASSERT_TRUE(
+        std::ranges::any_of(teams, [generatedTeam](const std::string_view& team) { return generatedTeam == team; }));
+}
+
+TEST_F(EsportTest, shouldGenerateLeague)
+{
+    const auto generatedLeague = league();
+
+    ASSERT_TRUE(std::ranges::any_of(leagues, [generatedLeague](const std::string_view& league)
+                                    { return generatedLeague == league; }));
+}
+
+TEST_F(EsportTest, shouldGenerateEvent)
+{
+    const auto generatedEvent = event();
+
+    ASSERT_TRUE(std::ranges::any_of(events, [generatedEvent](const std::string_view& event)
+                                    { return generatedEvent == event; }));
+}
+
+TEST_F(EsportTest, shouldGenerateGame)
+{
+    const auto generatedGame = game();
+
+    ASSERT_TRUE(
+        std::ranges::any_of(games, [generatedGame](const std::string_view& game) { return generatedGame == game; }));
+}


### PR DESCRIPTION
Add a new e-sport module with the following methods:

- std::string_view player();
- std::string_view team();
- std::string_view league();
- std::string_view event();
- std::string_view game();