### PR TITLE
feat: create video module (#770)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ int main()
 - 📚 Lorem - lorem words, sentences, paragraphs
 - 🏥 Medicine - conditions, medical tests, specialties
 - 🎥 Movie - actors, actresses, genres, movie titles
+- 🎞️ Video - format name, file extension, video codec, audio codec, resolution, aspect ratio, video url
 - 🎶 Music - artists, song names, genres
 - 🔢 Number - random integers, floating point numbers
 - 🧑 Person - first, last names, job titles, hobby, genders, sex, nationality, language
@@ -115,6 +116,7 @@ int main()
 - 💻 System - file paths, file extensions, file names, directories, semantic version
 - 🚗 Vehicle - vehicle types, makes, models, fuel types, license plates
 - 🎮 Video game - title, genre, platform, studio
+- 🕹️ Esport - player, team, league, event, game
 - 🌤️ Weather - temperature, pressure, humidity, weather description
 - 💬 Word - sample words, nouns, verbs
 

--- a/include/faker-cxx/video.h
+++ b/include/faker-cxx/video.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <string_view>
+
+#include "faker-cxx/export.h"
+
+namespace faker::video
+{
+/**
+ * @brief Returns a random format name .
+ *
+ * @returns Format name.
+ *
+ * @code
+ * faker::video::formatName() // "Ogg Video"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view formatName();
+
+/**
+ * @brief Returns a random file extension.
+ *
+ * @returns File extension.
+ *
+ * @code
+ * faker::video::fileExtension() // ".webm"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view fileExtension();
+
+/**
+ * @brief Returns a random video codec.
+ *
+ * @returns Video codec.
+ *
+ * @code
+ * faker::video::videoCodec() // "VP8"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view videoCodec();
+
+/**
+ * @brief Returns a random audio codec.
+ *
+ * @returns Audio Codec.
+ *
+ * @code
+ * faker::video::audioCodec() // "Vorbis"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view audioCodec();
+
+/**
+ * @brief Returns a random resolution.
+ *
+ * @returns Resolution.
+ *
+ * @code
+ * faker::video::resolution() // "240p"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view resolution();
+
+/**
+ * @brief Returns a random aspect ratio.
+ *
+ * @returns Aspect Ratio.
+ *
+ * @code
+ * faker::video::aspectRatio() // "16:9"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view aspectRatio();
+
+/**
+ * @brief Returns a random video Url.
+ *
+ * @returns Video Url.
+ *
+ * @code
+ * faker::video::videoUrl() // "https://youtu.be/_7ONEaabK90"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string_view videoUrl();
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ set(FAKER_SOURCES
     modules/system.cpp
     modules/vehicle.cpp
     modules/video_game.cpp
+    modules/video.cpp
     modules/weather.cpp
     modules/word.cpp
     common/format_helper.cpp
@@ -56,6 +57,7 @@ set(FAKER_HEADERS
     modules/book_data.h
     modules/string_data.h
     modules/video_game_data.h
+    modules/video_data.h
     modules/medicine_data.h
     modules/vehicle_data.h
     modules/hacker_data.h

--- a/src/modules/video.cpp
+++ b/src/modules/video.cpp
@@ -1,0 +1,44 @@
+#include "faker-cxx/video.h"
+
+#include <string_view>
+
+#include "faker-cxx/helper.h"
+#include "video_data.h"
+
+namespace faker::video
+{
+std::string_view formatName()
+{
+    return helper::randomElement(formatNames);
+}
+
+std::string_view fileExtension()
+{
+    return helper::randomElement(fileExtensions);
+}
+
+std::string_view videoCodec()
+{
+    return helper::randomElement(videoCodecs);
+}
+
+std::string_view audioCodec()
+{
+    return helper::randomElement(audioCodecs);
+}
+
+std::string_view resolution()
+{
+    return helper::randomElement(resolutions);
+}
+
+std::string_view aspectRatio()
+{
+    return helper::randomElement(aspectRatios);
+}
+
+std::string_view videoUrl()
+{
+    return helper::randomElement(videoUrls);
+}
+}

--- a/src/modules/video_data.h
+++ b/src/modules/video_data.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace faker::video
+{
+const auto formatNames = std::to_array<std::string_view>({"WebM",
+                                                          "Matroska",
+                                                          "Flash Video (FLV)",
+                                                          "F4V",
+                                                          "Vob",
+                                                          "Ogg Video",
+                                                          "Dirac",
+                                                          "GIF",
+                                                          "Video alternative to GIF",
+                                                          "Multiple-image Network Graphics",
+                                                          "AVI",
+                                                          "MPEG Transport Stream",
+                                                          "QuickTime File Format",
+                                                          "Windows Media Video",
+                                                          "Raw video format",
+                                                          "RealMedia (RM)",
+                                                          "RealMedia Variable Bitrate (RMVB)",
+                                                          "VivoActive (VIV)",
+                                                          "Advanced Systems Format (ASF)",
+                                                          "AMV video format",
+                                                          "MPEG-4 Part 14 (MP4)",
+                                                          "MPEG-1",
+                                                          "MPEG-2",
+                                                          "M4V",
+                                                          "SVI",
+                                                          "3GPP",
+                                                          "3GPP2",
+                                                          "Material Exchange Format (MXF)",
+                                                          "ROQ",
+                                                          "Nullsoft Streaming Video (NSV)"});
+
+const auto fileExtensions = std::to_array<std::string_view>(
+    {".webm", ".mkv", ".flv",  ".vob", ".ogv", ".ogg", ".drc",  ".gif", ".gifv", ".mng", ".avi", ".MTS", ".M2TS",
+     ".TS",   ".mov", ".qt",   ".wmv", ".yuv", ".rm",  ".rmvb", ".viv", ".asf",  ".amv", ".mp4", ".m4p", ".m4v",
+     ".mpg",  ".mp2", ".mpeg", ".mpe", ".mpv", ".m2v", ".svi",  ".3gp", ".3g2",  ".mxf", ".roq", ".nsv"});
+
+const auto videoCodecs = std::to_array<std::string_view>(
+    {"VP8", "VP9", "AV1", "VP6", "Sorenson Spark", "H.264", "H.262/MPEG-2 Part 2", "MPEG-1 Part 2", "Theora", "Dirac",
+     "H.263", "Motion JPEG", "H.265", "MPEG-4 Part 2", "MPEG-1 Part 2", "H.262", "RealVideo"});
+
+const auto audioCodecs = std::to_array<std::string_view>({"Vorbis",
+                                                          "Opus",
+                                                          "MP3",
+                                                          "ADPCM",
+                                                          "Nellymoser",
+                                                          "Speex",
+                                                          "AAC",
+                                                          "PCM",
+                                                          "DTS",
+                                                          "MPEG-1 Audio Layer II (MP2)",
+                                                          "Dolby Digital (AC-3)",
+                                                          "FLAC",
+                                                          "AMR-NB",
+                                                          "AMR-WB",
+                                                          "AMR-WB+",
+                                                          "HE-AAC v1",
+                                                          "Enhanced aacPlus (HE-AAC v2)",
+                                                          "RealAudio",
+                                                          "G.723 ADPCM",
+                                                          "IMA",
+                                                          "Dolby AC-4",
+                                                          "Sipro ACELP.net",
+                                                          "Advanced Audio Coding",
+                                                          "G.723 ADPCM audio",
+                                                          "EVRC",
+                                                          "SMV",
+                                                          "VMR-WB"});
+
+const auto resolutions =
+    std::to_array<std::string_view>({"240p", "360p", "480p", "720p", "1080p", "1440p", "4K", "8k"});
+
+const auto aspectRatios = std::to_array<std::string_view>(
+    {"1:1", "4:3", "14:9", "16:10", "16:9", "1.85:1", "2.00:1", "2.40:1", "32:0", "21:9"});
+
+const auto videoUrls = std::to_array<std::string_view>(
+    {"https://youtu.be/_7ONEaabK90", "https://youtu.be/Jb4prVsXkZU", "https://youtu.be/XC1iWDz2gkk",
+     "https://youtu.be/YjxgM4Wvcts", "https://youtu.be/9RGPe-rYlnQ", "https://youtu.be/a91oTLx-1No",
+     "https://youtu.be/f21UCwIfgZk", "https://youtu.be/TvAuyIinmpI", "https://youtu.be/oavMtUWDBTM",
+     "https://youtu.be/hMnk7lh9M3o", "https://youtu.be/tpr8oqyjKIc", "https://youtu.be/idRjqi8JC2U",
+     "https://youtu.be/4-94JhLEiN0", "https://youtu.be/t7JCh7PHoDc", "https://youtu.be/AXOa66-k9MA",
+     "https://youtu.be/TE4eplsFSms", "https://youtu.be/04v_v1gnyO8", "https://youtu.be/pIsae6YdRjw",
+     "https://youtu.be/NHE7migQN7U", "https://youtu.be/FJ3oHpup-pk", "https://youtu.be/6JFVKnrE_d8"});
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(FAKER_UT_SOURCES
     modules/vehicle_test.cpp
     modules/version_test.cpp
     modules/video_game_test.cpp
+    modules/video_test.cpp
     modules/weather_test.cpp
     modules/word_test.cpp
     modules/word_data_test.cpp

--- a/tests/modules/video_test.cpp
+++ b/tests/modules/video_test.cpp
@@ -1,0 +1,72 @@
+#include <algorithm>
+#include <string_view>
+
+#include "gtest/gtest.h"
+
+#include "faker-cxx/video.h"
+#include "video_data.h"
+
+using namespace ::testing;
+using namespace faker;
+using namespace faker::video;
+
+class VideoTest : public Test
+{
+public:
+};
+
+TEST_F(VideoTest, shouldGenerateFormatName)
+{
+    const auto generatedFormatName = formatName();
+
+    ASSERT_TRUE(std::ranges::any_of(formatNames, [generatedFormatName](const std::string_view& formatName)
+                                    { return formatName == generatedFormatName; }));
+}
+
+TEST_F(VideoTest, shouldGenerateFileExtension)
+{
+    const auto generatedFileExtension = fileExtension();
+
+    ASSERT_TRUE(std::ranges::any_of(fileExtensions, [generatedFileExtension](const std::string_view& fileExtension)
+                                    { return fileExtension == generatedFileExtension; }));
+}
+
+TEST_F(VideoTest, shouldGenerateVideoCodec)
+{
+    const auto generatedVideoCodec = videoCodec();
+
+    ASSERT_TRUE(std::ranges::any_of(videoCodecs, [generatedVideoCodec](const std::string_view& videoCodec)
+                                    { return videoCodec == generatedVideoCodec; }));
+}
+
+TEST_F(VideoTest, shouldGeneratedAudioCodec)
+{
+    const auto generatedAudioCodec = audioCodec();
+
+    ASSERT_TRUE(std::ranges::any_of(audioCodecs, [generatedAudioCodec](const std::string_view& audioCodec)
+                                    { return audioCodec == generatedAudioCodec; }));
+}
+
+TEST_F(VideoTest, shouldGenerateResolution)
+{
+    const auto generatedResolution = resolution();
+
+    ASSERT_TRUE(std::ranges::any_of(resolutions, [generatedResolution](const std::string_view& resolution)
+                                    { return resolution == generatedResolution; }));
+}
+
+TEST_F(VideoTest, shouldGenerateAspectRatio)
+{
+    const auto generatedAspectRatio = aspectRatio();
+
+    ASSERT_TRUE(std::ranges::any_of(aspectRatios, [generatedAspectRatio](const std::string_view& aspectRatio)
+                                    { return aspectRatio == generatedAspectRatio; }));
+}
+
+TEST_F(VideoTest, shouldGenerateVideoUrl)
+{
+    const auto generatedVideoUrl = videoUrl();
+
+    ASSERT_TRUE(std::ranges::any_of(videoUrls, [generatedVideoUrl](const std::string_view& videoUrl)
+                                    { return videoUrl == generatedVideoUrl; }));
+}


### PR DESCRIPTION
Create video module with following methods:

- formatName
- fileExtension
- videoCodec
- audioCodec
- resolution
- aspectRatio
- videoUrl