### PR TITLE
Updated apple-clang-compilation-guide 

### DIFF
--- a/docs/guides/apple-clang-compilation-guide.md
+++ b/docs/guides/apple-clang-compilation-guide.md
@@ -35,7 +35,7 @@ cmake --build ./build
 ## 5. Run tests
 
 ```bash
-./faker-cxx-UT
+./build/tests/faker-cxx-UT
 ```
 
 or using CTest:


### PR DESCRIPTION
Updated apple-clang-compilation-guide to include correct path of faker-cxx-UT to run tests 