### PR TITLE
fix: Fixed some flaky tests dues to floating point errors

### DIFF
--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -232,11 +232,16 @@ std::tuple<std::string, std::string> nearbyGPSCoordinate(Precision precision, co
     const auto radiusMetric = isMetric ? radius : radius * 1.60934;
     const auto distanceInKm = number::decimal<double>(radiusMetric);
 
-    constexpr auto kmPerDegree = 40000 / 360; // The distance in km per degree for earth.
-    const auto distanceInDegree = distanceInKm / kmPerDegree;
+    constexpr auto kmPerDegreeLatitude = 110.574; // The distance in km per degree for earth's latitude.
+    const auto kmPerDegreeLongitude =
+        111.320 *
+        std::cos(std::get<0>(origin) / 180 * M_PI); // The distance in km per degree for a specific longitude in earth.
 
-    auto coordinateLatitude = std::get<0>(origin) + distanceInDegree * std::sin(angleRadians);
-    auto coordinateLongitude = std::get<1>(origin) + distanceInDegree * std::cos(angleRadians);
+    const auto distanceInDegreeLatitude = distanceInKm / kmPerDegreeLatitude;
+    const auto distanceInDegreeLongitude = distanceInKm / kmPerDegreeLongitude;
+
+    auto coordinateLatitude = std::get<0>(origin) + distanceInDegreeLatitude * std::sin(angleRadians);
+    auto coordinateLongitude = std::get<1>(origin) + distanceInDegreeLongitude * std::cos(angleRadians);
 
     // Box the latitude [-90, 90]
     coordinateLatitude = std::fmod(coordinateLatitude, 180.0);


### PR DESCRIPTION
<!-- Please run build and tests before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md#committing -->

Fixed `shouldGenerateNearbyGPSCoordinateWithOriginInKilometers` and `shouldGenerateNearbyGPSCoordinateWithOriginInMiles`

Ran all tests locally using the following python script:
```
import subprocess
from tqdm import tqdm

def run_command(command):
    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
    output, error = process.communicate()
    if process.returncode != 0:
        print(f"Command failed with exit code {process.returncode}:")
        print(error.decode())
        return False
    return output.decode()

def run_command_with_progress_bar(command, iterations):
    for i in tqdm(range(iterations), desc="Running command", unit="iteration"):
        output = run_command(command)
        if output is None:
            break

if __name__ == "__main__":
    command = "ctest"
    iterations = 100
    run_command_with_progress_bar(command, iterations)
```

The test shouldGenerateSlovakiaStreetAddress is also flaky returning out of bounds errors sometimes.

