### PR TITLE
feat: add locale to plant module

### DIFF
--- a/include/faker-cxx/plant.h
+++ b/include/faker-cxx/plant.h
@@ -23,6 +23,8 @@ FAKER_CXX_EXPORT std::string_view tree(Locale locale = Locale::en_US);
 /**
  * @brief Returns a random species of flower.
  *
+ * @param locale The locale. Defaults to `Locale::en_US`.
+ *
  * @returns Species of flower.
  *
  * @code
@@ -33,6 +35,8 @@ FAKER_CXX_EXPORT std::string_view flower(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of shrub.
+ *
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @returns Species of shrub.
  *
@@ -45,6 +49,8 @@ FAKER_CXX_EXPORT std::string_view shrub(Locale locale = Locale::en_US);
 /**
  * @brief Returns a random species of grass.
  *
+ * @param locale The locale. Defaults to `Locale::en_US`.
+ *
  * @returns Species of grass.
  *
  * @code
@@ -55,6 +61,8 @@ FAKER_CXX_EXPORT std::string_view grass(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of fern.
+ *
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @returns Species of fern.
  *
@@ -67,6 +75,8 @@ FAKER_CXX_EXPORT std::string_view fern(Locale locale = Locale::en_US);
 /**
  * @brief Returns a random species of succulent.
  *
+ * @param locale The locale. Defaults to `Locale::en_US`.
+ *
  * @returns Species of succulent.
  *
  * @code
@@ -78,6 +88,8 @@ FAKER_CXX_EXPORT std::string_view succulent(Locale locale = Locale::en_US);
 /**
  * @brief Returns a random species of vine.
  *
+ * @param locale The locale. Defaults to `Locale::en_US`.
+ *
  * @returns Species of vine.
  *
  * @code
@@ -88,6 +100,8 @@ FAKER_CXX_EXPORT std::string_view vine(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random type of plant.
+ *
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @returns Type of plant.
  *

--- a/include/faker-cxx/plant.h
+++ b/include/faker-cxx/plant.h
@@ -3,11 +3,14 @@
 #include <string_view>
 
 #include "faker-cxx/export.h"
+#include "faker-cxx/types/locale.h"
 
 namespace faker::plant
 {
 /**
  * @brief Returns a random species of tree.
+ *
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @returns Species of tree.
  *
@@ -15,7 +18,7 @@ namespace faker::plant
  * faker::plant::tree() // "Oak"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view tree();
+FAKER_CXX_EXPORT std::string_view tree(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of flower.
@@ -26,7 +29,7 @@ FAKER_CXX_EXPORT std::string_view tree();
  * faker::plant::flower() // "Rose"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view flower();
+FAKER_CXX_EXPORT std::string_view flower(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of shrub.
@@ -37,7 +40,7 @@ FAKER_CXX_EXPORT std::string_view flower();
  * faker::plant::shrub() // "Azalea"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view shrub();
+FAKER_CXX_EXPORT std::string_view shrub(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of grass.
@@ -48,7 +51,7 @@ FAKER_CXX_EXPORT std::string_view shrub();
  * faker::plant::grass() // "Kentucky Bluegrass"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view grass();
+FAKER_CXX_EXPORT std::string_view grass(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of fern.
@@ -59,7 +62,7 @@ FAKER_CXX_EXPORT std::string_view grass();
  * faker::plant::fern() // "Maidenhair"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view fern();
+FAKER_CXX_EXPORT std::string_view fern(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of succulent.
@@ -70,7 +73,7 @@ FAKER_CXX_EXPORT std::string_view fern();
  * faker::plant::succulent() // "Aloe Vera"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view succulent();
+FAKER_CXX_EXPORT std::string_view succulent(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random species of vine.
@@ -81,7 +84,7 @@ FAKER_CXX_EXPORT std::string_view succulent();
  * faker::plant::vine() // "Ivy"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view vine();
+FAKER_CXX_EXPORT std::string_view vine(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random type of plant.
@@ -92,5 +95,5 @@ FAKER_CXX_EXPORT std::string_view vine();
  * faker::plant::type() // "tree"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view plantType();
+FAKER_CXX_EXPORT std::string_view plantType(Locale locale = Locale::en_US);
 }

--- a/src/modules/plant.cpp
+++ b/src/modules/plant.cpp
@@ -7,43 +7,71 @@
 
 namespace faker::plant
 {
-std::string_view tree()
+namespace
 {
-    return helper::randomElement(trees);
+const struct PlantDefinition& getPlantDefinition(Locale locale)
+{
+    switch (locale)
+    {
+    default:
+        return enUSPlantDefinition;
+    }
+}
 }
 
-std::string_view flower()
+std::string_view tree(Locale locale)
 {
-    return helper::randomElement(flowers);
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.trees);
 }
 
-std::string_view shrub()
+std::string_view flower(Locale locale)
 {
-    return helper::randomElement(shrubs);
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.flowers);
 }
 
-std::string_view grass()
+std::string_view shrub(Locale locale)
 {
-    return helper::randomElement(grasses);
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.shrubs);
 }
 
-std::string_view fern()
+std::string_view grass(Locale locale)
 {
-    return helper::randomElement(ferns);
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.grasses);
 }
 
-std::string_view succulent()
+std::string_view fern(Locale locale)
 {
-    return helper::randomElement(succulents);
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.ferns);
 }
 
-std::string_view vine()
+std::string_view succulent(Locale locale)
 {
-    return helper::randomElement(vines);
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.succulents);
 }
 
-std::string_view plantType()
+std::string_view vine(Locale locale)
 {
-    return helper::randomElement(plantTypes);
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.vines);
+}
+
+std::string_view plantType(Locale locale)
+{
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    return helper::randomElement(plantDefinition.plantTypes);
 }
 }

--- a/src/modules/plant_data.h
+++ b/src/modules/plant_data.h
@@ -1,11 +1,24 @@
 #pragma once
 
 #include <array>
+#include <span>
 #include <string_view>
 
 namespace faker::plant
 {
-const auto trees = std::to_array<std::string_view>({
+struct PlantDefinition
+{
+    std::span<const std::string_view> trees;
+    std::span<const std::string_view> flowers;
+    std::span<const std::string_view> shrubs;
+    std::span<const std::string_view> grasses;
+    std::span<const std::string_view> ferns;
+    std::span<const std::string_view> succulents;
+    std::span<const std::string_view> vines;
+    std::span<const std::string_view> plantTypes;
+};
+
+const auto enUSTrees = std::to_array<std::string_view>({
     "Acacia",   "Almond",       "Apple",      "Ash",          "Avocado",        "Bamboo",  "Banana",
     "Baobab",   "Beech",        "Birch",      "Black Walnut", "Catalpa",        "Cedar",   "Cherry Blossom",
     "Chestnut", "Chestnut Oak", "Cottonwood", "Crape Myrtle", "Cypress",        "Dogwood", "Eucalyptus",
@@ -15,7 +28,7 @@ const auto trees = std::to_array<std::string_view>({
     "Spruce",   "Sycamore",     "Tamarind",   "Walnut",       "Willow",
 });
 
-const auto flowers = std::to_array<std::string_view>({
+const auto enUSFlowers = std::to_array<std::string_view>({
     "Adenium Obesum",
     "African Daisy",
     "Allamanda Cathartica",
@@ -110,7 +123,7 @@ const auto flowers = std::to_array<std::string_view>({
     "Zinnia",
 });
 
-const auto shrubs = std::to_array<std::string_view>({
+const auto enUSShrubs = std::to_array<std::string_view>({
     "Aralia",        "Arctostaphylos", "Aronia",         "Artemisia",     "Aucuba",       "Berberis",
     "Bougainvillea", "Brugmansia",     "Buddleja",       "Buxus",         "Calia",        "Callicarpa",
     "Callistemon",   "Calluna",        "Calycanthus",    "Camellia",      "Caragana",     "Carpenteria",
@@ -149,7 +162,7 @@ const auto shrubs = std::to_array<std::string_view>({
     "Zenobia",       "Ziziphus",
 });
 
-const auto grasses = std::to_array<std::string_view>({
+const auto enUSGrasses = std::to_array<std::string_view>({
     "Bahiagrass",
     "Bahiagrass",
     "Bamboo",
@@ -249,7 +262,7 @@ const auto grasses = std::to_array<std::string_view>({
     "Yellow Indiangrass",
 });
 
-const auto ferns = std::to_array<std::string_view>({
+const auto enUSFerns = std::to_array<std::string_view>({
     "Adder's-tongue Fern",
     "Angiopteris evecta",
     "Beech Fern",
@@ -336,7 +349,7 @@ const auto ferns = std::to_array<std::string_view>({
     "Zygopteridales",
 });
 
-const auto succulents = std::to_array<std::string_view>({
+const auto enUSSucculents = std::to_array<std::string_view>({
     "Aeonium",
     "Aloe vera",
     "Ammocharis",
@@ -470,7 +483,7 @@ const auto succulents = std::to_array<std::string_view>({
     "Zephyrlily",
 });
 
-const auto vines = std::to_array<std::string_view>({
+const auto enUSVines = std::to_array<std::string_view>({
     "Akebia (Five-leaf Akebia)",
     "Asparagus asparagoides (Sprenger's Asparagus)",
     "Black-eyed Susan Vine (Thunbergia alata)",
@@ -497,7 +510,7 @@ const auto vines = std::to_array<std::string_view>({
     "Wisteria",
 });
 
-const auto plantTypes = std::to_array<std::string_view>({
+const auto enUSPlantTypes = std::to_array<std::string_view>({
     "fern",
     "flower",
     "grass",
@@ -506,5 +519,16 @@ const auto plantTypes = std::to_array<std::string_view>({
     "tree",
     "vine",
 });
+
+const PlantDefinition enUSPlantDefinition = {
+    .trees = enUSTrees,
+    .flowers = enUSFlowers,
+    .shrubs = enUSShrubs,
+    .grasses = enUSGrasses,
+    .ferns = enUSFerns,
+    .succulents = enUSSucculents,
+    .vines = enUSVines,
+    .plantTypes = enUSPlantTypes,
+};
 
 }

--- a/tests/modules/plant_test.cpp
+++ b/tests/modules/plant_test.cpp
@@ -7,73 +7,121 @@
 #include "plant_data.h"
 
 using namespace ::testing;
+using namespace faker;
 using namespace faker::plant;
 
-class PlantTest : public Test
+namespace
+{
+const struct PlantDefinition& getPlantDefinition(Locale locale)
+{
+    switch (locale)
+    {
+    default:
+        return enUSPlantDefinition;
+    }
+}
+}
+
+class PlantTest : public TestWithParam<Locale>
 {
 public:
 };
 
-TEST_F(PlantTest, shouldGenerateTree)
+TEST_P(PlantTest, shouldGenerateTree)
 {
-    const auto generatedTree = tree();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(
-        std::ranges::any_of(trees, [generatedTree](const std::string_view& tree) { return tree == generatedTree; }));
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedTree = tree(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.trees,
+                                    [generatedTree](const std::string_view& tree) { return tree == generatedTree; }));
 }
 
-TEST_F(PlantTest, shouldGenerateFlower)
+TEST_P(PlantTest, shouldGenerateFlower)
 {
-    const auto generatedFlower = flower();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(std::ranges::any_of(flowers, [generatedFlower](const std::string_view& flower)
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedFlower = flower(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.flowers, [generatedFlower](const std::string_view& flower)
                                     { return flower == generatedFlower; }));
 }
 
-TEST_F(PlantTest, shouldGenerateShrub)
+TEST_P(PlantTest, shouldGenerateShrub)
 {
-    const auto generatedShrub = shrub();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(std::ranges::any_of(shrubs, [generatedShrub](const std::string_view& shrub)
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedShrub = shrub(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.shrubs, [generatedShrub](const std::string_view& shrub)
                                     { return shrub == generatedShrub; }));
 }
 
-TEST_F(PlantTest, shouldGenerateGrass)
+TEST_P(PlantTest, shouldGenerateGrass)
 {
-    const auto generatedGrass = grass();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(std::ranges::any_of(grasses, [generatedGrass](const std::string_view& grass)
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedGrass = grass(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.grasses, [generatedGrass](const std::string_view& grass)
                                     { return grass == generatedGrass; }));
 }
 
-TEST_F(PlantTest, shouldGenerateFern)
+TEST_P(PlantTest, shouldGenerateFern)
 {
-    const auto generatedFern = fern();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(
-        std::ranges::any_of(ferns, [generatedFern](const std::string_view& fern) { return fern == generatedFern; }));
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedFern = fern(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.ferns,
+                                    [generatedFern](const std::string_view& fern) { return fern == generatedFern; }));
 }
 
-TEST_F(PlantTest, shouldGenerateSucculent)
+TEST_P(PlantTest, shouldGenerateSucculent)
 {
-    const auto generatedSucculent = succulent();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(std::ranges::any_of(succulents, [generatedSucculent](const std::string_view& succulent)
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedSucculent = succulent(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.succulents, [generatedSucculent](const std::string_view& succulent)
                                     { return succulent == generatedSucculent; }));
 }
 
-TEST_F(PlantTest, shouldGenerateVine)
+TEST_P(PlantTest, shouldGenerateVine)
 {
-    const auto generatedVine = vine();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(
-        std::ranges::any_of(vines, [generatedVine](const std::string_view& vine) { return vine == generatedVine; }));
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedVine = vine(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.vines,
+                                    [generatedVine](const std::string_view& vine) { return vine == generatedVine; }));
 }
 
-TEST_F(PlantTest, shouldGenerateType)
+TEST_P(PlantTest, shouldGenerateType)
 {
-    const auto generatedType = plantType();
+    const auto locale = GetParam();
 
-    ASSERT_TRUE(std::ranges::any_of(plantTypes, [generatedType](const std::string_view& plantType)
+    const auto& plantDefinition = getPlantDefinition(locale);
+
+    const auto generatedType = plantType(locale);
+
+    ASSERT_TRUE(std::ranges::any_of(plantDefinition.plantTypes, [generatedType](const std::string_view& plantType)
                                     { return plantType == generatedType; }));
 }
+
+INSTANTIATE_TEST_SUITE_P(TestPlantByLocale, PlantTest, ValuesIn(locales),
+                         [](const TestParamInfo<Locale>& paramInfo) { return toString(paramInfo.param); });


### PR DESCRIPTION
This PR introduces locale support in the plant module, with `enUS` set as the default. 

Fixes Issue: #898

Changes:
1. Locale Parameter for Plant Definitions
   - Added `getPlantDefinition()` with locale as parameter to support locale-based plant data.
   - Defaulted to `enUS` as a fallback for undefined or unsupported locales:
    ```cpp
   const struct PlantDefinition& getPlantDefinition(Locale locale) {
       switch (locale) {
        default:
            return enUSPlantDefinition;
        }
    }
    ```
2. Locale-Specific Naming in Plant Data
   - Updated array naming for plant data, to reflect the locale:
    ```cpp
    const auto enUSTrees = std::to_array<std::string_view> {/* data */};
     ```
3. Test Suite Updates
    - Updated `plant_test` to incorporate the new locale parameter.
---
- [x] Ran all unit tests after building project to ensure no breakage from the locale addition.