### PR TITLE
ci: add clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,49 @@
+name: clang-format Check
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'src/**/*.cpp'
+      - 'src/**/*.h'
+      - 'include/**/*.h'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/**/*.cpp'
+      - 'src/**/*.h'
+      - 'include/**/*.h'
+
+jobs:
+  check_formatting:
+    name: Check Code Formatting
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache clang-format dependencies
+        uses: actions/cache@v3
+        with:
+          path: /tmp/apt-cache
+          key: clang-format-${{ runner.os }}-${{ hashFiles('**/apt-packages.txt') }}
+          restore-keys: |
+            clang-format-${{ runner.os }}-
+
+      - name: Install clang-format
+        run: |
+          if [ ! -f /tmp/apt-cache/clang-format-18 ]; then
+            sudo apt-get update
+            sudo apt-get install -y clang-format-18
+            touch /tmp/apt-cache/clang-format-18
+          fi
+
+      - name: Run clang-format
+        run: |
+          clang-format src/**/*.cpp src/**/*.h include/**/*.h -i -style=file
+
+      - name: Check for unformatted files
+        run: |
+          git diff --exit-code || (echo "Code is not formatted correctly" && exit 1)


### PR DESCRIPTION
This closes #953 

This PR introduces a GitHub Action to check code formatting using clang-format.

## Workflow
- Runs only on push and pull_request events for `include/**/*.h`,`src/**/*.cpp` and `src/**/*.h` files.
- Cache check for `clang-format-18` to avoid re-installation if it is already installed.
- Validates formatting using git diff and fails the workflow if unformatted files are detected.