### PR TITLE
fix: run clang format

### DIFF
--- a/include/faker-cxx/helper.h
+++ b/include/faker-cxx/helper.h
@@ -10,8 +10,8 @@ namespace faker::helper
 {
 
 template <typename T>
-concept input_range_with_faster_size_compute_than_linear_rng = std::ranges::input_range<T> &&
-    (std::ranges::sized_range<T> || std::ranges::forward_range<T>);
+concept input_range_with_faster_size_compute_than_linear_rng =
+    std::ranges::input_range<T> && (std::ranges::sized_range<T> || std::ranges::forward_range<T>);
 
 template <input_range_with_faster_size_compute_than_linear_rng Range>
 decltype(auto) randomElement(Range&& range)

--- a/include/faker-cxx/location.h
+++ b/include/faker-cxx/location.h
@@ -31,11 +31,10 @@ FAKER_CXX_EXPORT std::string_view country();
  * @code
  * faker::location::continent("Poland") // Europe
  * faker::location::continent() // Africa
- * 
+ *
  * @endcode
  */
 FAKER_CXX_EXPORT std::string_view continent(std::string_view country = "");
-
 
 /**
  * @brief Returns a random country code.

--- a/include/faker-cxx/random_generator.h
+++ b/include/faker-cxx/random_generator.h
@@ -6,7 +6,7 @@
 namespace faker
 {
 template <typename T>
-requires std::uniform_random_bit_generator<T>
+    requires std::uniform_random_bit_generator<T>
 
 class RandomGenerator
 {
@@ -21,7 +21,7 @@ public:
     RandomGenerator& operator=(RandomGenerator&&) = default;
 
     template <typename Dist>
-    requires std::is_invocable_r_v<int, Dist&, T&>
+        requires std::is_invocable_r_v<int, Dist&, T&>
 
     int operator()(Dist&& dist)
     {

--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -1,17 +1,17 @@
 #include "faker-cxx/location.h"
 
-
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
-#include <stdexcept>
-#include "faker-cxx/types/locale.h"
+
 #include "common/algo_helper.h"
 #include "common/format_helper.h"
 #include "faker-cxx/helper.h"
 #include "faker-cxx/number.h"
 #include "faker-cxx/person.h"
+#include "faker-cxx/types/locale.h"
 #include "faker-cxx/types/precision.h"
 #include "location_data.h"
 
@@ -92,8 +92,8 @@ CountryAddressesInfo getAddresses(const Locale& locale)
 
 std::string_view continent(std::string_view country)
 {
-    static const std::vector<std::string_view> continents = {
-        "Africa", "Antarctica", "Asia", "Europe", "North America", "Australia", "South America"};
+    static const std::vector<std::string_view> continents = {"Africa",        "Antarctica", "Asia",         "Europe",
+                                                             "North America", "Australia",  "South America"};
 
     if (country.empty())
     {
@@ -108,9 +108,6 @@ std::string_view continent(std::string_view country)
 
     return "Unknown";
 }
-
-
-
 
 std::string_view country()
 {

--- a/src/modules/location_data.h
+++ b/src/modules/location_data.h
@@ -23,18 +23,11 @@ struct CountryAddressesInfo
     std::span<const std::string_view> states;
 };
 
-const auto allContinents = std::to_array<std::string_view>({
-    "Africa",
-    "Antarctica",
-    "Asia",
-    "Europe",
-    "North America",
-    "Australia",
-    "South America"
-});
+const auto allContinents = std::to_array<std::string_view>(
+    {"Africa", "Antarctica", "Asia", "Europe", "North America", "Australia", "South America"});
 
 const std::unordered_map<std::string_view, std::string_view> countryToContinent = {
-{"Afghanistan", "Asia"},
+    {"Afghanistan", "Asia"},
     {"Aland Islands", "Europe"},
     {"Albania", "Europe"},
     {"Algeria", "Africa"},
@@ -211,7 +204,7 @@ const std::unordered_map<std::string_view, std::string_view> countryToContinent 
     {"Portugal", "Europe"},
     {"Puerto Rico", "North America"},
     {"Qatar", "Asia"},
-     {"Republic of Korea", "Asia"},
+    {"Republic of Korea", "Asia"},
     {"Reunion", "Africa"},
     {"Romania", "Europe"},
     {"Russian Federation", "Europe/Asia"},
@@ -279,8 +272,7 @@ const std::unordered_map<std::string_view, std::string_view> countryToContinent 
     {"Western Sahara", "Africa"},
     {"Yemen", "Asia"},
     {"Zambia", "Africa"},
-    {"Zimbabwe", "Africa"}
-};
+    {"Zimbabwe", "Africa"}};
 
 const auto allCountries = std::to_array<std::string_view>({
     // clang-format off
@@ -7659,41 +7651,20 @@ const auto israelStreetNames = std::to_array<std::string_view>({
     "תשבי",
 });
 
-const auto israelStreetPrefixes = std::to_array<std::string_view>({
-    "רחוב", 
-    "שדרות", 
-    "משעול", 
-    "דרך", 
-    "סמטת"
-});
+const auto israelStreetPrefixes = std::to_array<std::string_view>({"רחוב", "שדרות", "משעול", "דרך", "סמטת"});
 
 const std::string_view israelZipCodeFormat{"#######"};
 
-const auto israelAddressFormats =
-    std::to_array<std::string_view>({
+const auto israelAddressFormats = std::to_array<std::string_view>({
     "{street} {buildingNumber}",
     "{street} {buildingNumber} {secondaryAddress}",
 });
 
-const auto israelSecondaryAddressFormats = std::to_array<std::string_view>({
-    "דירה #", 
-    "דירה ##", 
-    "חדר ##", 
-    "חדר #"
-});
+const auto israelSecondaryAddressFormats = std::to_array<std::string_view>({"דירה #", "דירה ##", "חדר ##", "חדר #"});
 
-const auto israelBuildingNumberFormats = std::to_array<std::string_view>({
-    "###", 
-    "##", 
-    "#", 
-    "##ב", 
-    "##א", 
-    "#א", 
-    "#ב"
-});
+const auto israelBuildingNumberFormats = std::to_array<std::string_view>({"###", "##", "#", "##ב", "##א", "#א", "#ב"});
 
-const auto israelStreetFormats =
-    std::to_array<std::string_view>({
+const auto israelStreetFormats = std::to_array<std::string_view>({
     "{streetPrefix} {streetName}",
 });
 

--- a/src/modules/person.cpp
+++ b/src/modules/person.cpp
@@ -237,9 +237,8 @@ std::string fullName(Locale locale, std::optional<Sex> sex)
     weightedElements.reserve(peopleNames.nameFormats.size());
 
     std::transform(peopleNames.nameFormats.begin(), peopleNames.nameFormats.end(), std::back_inserter(weightedElements),
-                   [](const NameFormat& nameFormat) {
-                       return helper::WeightedElement<std::string_view>{nameFormat.weight, nameFormat.format};
-                   });
+                   [](const NameFormat& nameFormat)
+                   { return helper::WeightedElement<std::string_view>{nameFormat.weight, nameFormat.format}; });
 
     const auto nameFormat = static_cast<std::string>(helper::weightedRandomElement<std::string_view>(weightedElements));
 

--- a/src/modules/string.cpp
+++ b/src/modules/string.cpp
@@ -358,5 +358,4 @@ std::string nanoId(int minLength, int maxLength)
     return id;
 }
 
-
 }


### PR DESCRIPTION
This PR fixes formatting in recently changed files using `clang-format`.
