### PR TITLE
feat: add Locale to sport module

### DIFF
--- a/include/faker-cxx/sport.h
+++ b/include/faker-cxx/sport.h
@@ -3,12 +3,13 @@
 #include <string_view>
 
 #include "faker-cxx/export.h"
+#include "faker-cxx/types/locale.h"
 
 namespace faker::sport
 {
 /**
  * @brief Returns a random sport.
- *
+ * @param locale The locale. Defaults to `Locale::en_US`.
  * @returns Sport.
  *
  * @code
@@ -16,21 +17,23 @@ namespace faker::sport
  * @endcode
  */
 
-FAKER_CXX_EXPORT std::string_view sportName();
+FAKER_CXX_EXPORT std::string_view sportName(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random soccer team.
  *
  * @returns Coccer team.
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @code
  * faker::sport::soccerTeam() // "Manchester United"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view soccerTeam();
+FAKER_CXX_EXPORT std::string_view soccerTeam(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random male athlete.
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @returns Male athlete.
  *
@@ -38,10 +41,11 @@ FAKER_CXX_EXPORT std::string_view soccerTeam();
  * faker::sport::maleAthlete() // "Cristiano Ronaldo"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view maleAthlete();
+FAKER_CXX_EXPORT std::string_view maleAthlete(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random female athlete.
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @returns Female athlete.
  *
@@ -49,10 +53,11 @@ FAKER_CXX_EXPORT std::string_view maleAthlete();
  * faker::sport::femaleAthlete() // "Serena Williams"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view femaleAthlete();
+FAKER_CXX_EXPORT std::string_view femaleAthlete(Locale locale = Locale::en_US);
 
 /**
  * @brief Returns a random Sport Event.
+ * @param locale The locale. Defaults to `Locale::en_US`.
  *
  * @returns Sport Event.
  *
@@ -60,5 +65,5 @@ FAKER_CXX_EXPORT std::string_view femaleAthlete();
  * faker::sport::sportEvent() // "Super Bowl"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string_view sportEvent();
+FAKER_CXX_EXPORT std::string_view sportEvent(Locale locale = Locale::en_US);
 }

--- a/src/modules/sport.cpp
+++ b/src/modules/sport.cpp
@@ -7,28 +7,53 @@
 
 namespace faker::sport
 {
-std::string_view sportName()
+std::string_view sportName(Locale locale)
 {
-    return helper::randomElement(sportNames);
+    auto localeLocal = locale;
+    if (sportMapSpan.find(locale) == sportMapSpan.end())
+    {
+        localeLocal = Locale::en_US;
+    }
+    return helper::randomElement((sportMapSpan.at(localeLocal)).sportNames);
 }
 
-std::string_view soccerTeam()
+std::string_view soccerTeam(Locale locale)
 {
-    return helper::randomElement(soccerTeams);
+    auto localeLocal = locale;
+    if (sportMapSpan.find(locale) == sportMapSpan.end())
+    {
+        localeLocal = Locale::en_US;
+    }
+    return helper::randomElement((sportMapSpan.at(localeLocal)).soccerTeams);
 }
 
-std::string_view maleAthlete()
+std::string_view maleAthlete(Locale locale)
 {
-    return helper::randomElement(maleAthletes);
+    auto localeLocal = locale;
+    if (sportMapSpan.find(locale) == sportMapSpan.end())
+    {
+        localeLocal = Locale::en_US;
+    }
+    return helper::randomElement((sportMapSpan.at(localeLocal)).maleAthletes);
 }
 
-std::string_view femaleAthlete()
+std::string_view femaleAthlete(Locale locale)
 {
-    return helper::randomElement(femaleAthletes);
+    auto localeLocal = locale;
+    if (sportMapSpan.find(locale) == sportMapSpan.end())
+    {
+        localeLocal = Locale::en_US;
+    }
+    return helper::randomElement((sportMapSpan.at(localeLocal)).femaleAthletes);
 }
 
-std::string_view sportEvent()
+std::string_view sportEvent(Locale locale)
 {
-    return helper::randomElement(sportEvents);
+    auto localeLocal = locale;
+    if (sportMapSpan.find(locale) == sportMapSpan.end())
+    {
+        localeLocal = Locale::en_US;
+    }
+    return helper::randomElement((sportMapSpan.at(localeLocal)).sportEvents);
 }
 }

--- a/src/modules/sport_data.h
+++ b/src/modules/sport_data.h
@@ -1,11 +1,25 @@
 #pragma once
 
 #include <array>
+#include <map>
+#include <span>
 #include <string>
+#include <string_view>
 
 namespace faker::sport
 {
-const auto femaleAthletes = std::to_array<std::string_view>({
+struct SportDefinition
+{
+    std::span<const std::string_view> femaleAthletes;
+    std::span<const std::string_view> maleAthletes;
+    std::span<const std::string_view> soccerTeams;
+    std::span<const std::string_view> sportEvents;
+    std::span<const std::string_view> sportNames;
+};
+
+//"en_US"
+
+const auto enUsFemaleAthletes = std::to_array<std::string_view>({
     "Alex Morgan",
     "Jackie Joyner-Kersee",
     "Lindsey Vonn",
@@ -18,7 +32,7 @@ const auto femaleAthletes = std::to_array<std::string_view>({
     "Steffi Graf",
 });
 
-const auto maleAthletes = std::to_array<std::string_view>({
+const auto enUSMaleAthletes = std::to_array<std::string_view>({
     "Cristiano Ronaldo",
     "Kobe Bryant",
     "LeBron James",
@@ -31,7 +45,7 @@ const auto maleAthletes = std::to_array<std::string_view>({
     "Usain Bolt",
 });
 
-const auto soccerTeams = std::to_array<std::string_view>({
+const auto enUSSoccerTeams = std::to_array<std::string_view>({
     "AC Milan",
     "Chelsea FC",
     "FC Barcelona",
@@ -44,7 +58,7 @@ const auto soccerTeams = std::to_array<std::string_view>({
     "Real Madrid CF",
 });
 
-const auto sportEvents = std::to_array<std::string_view>({
+const auto enUSSportEvents = std::to_array<std::string_view>({
     "ICC Cricket World Cup",
     "NBA Finals",
     "Olympics",
@@ -57,7 +71,7 @@ const auto sportEvents = std::to_array<std::string_view>({
     "World Cup",
 });
 
-const auto sportNames = std::to_array<std::string_view>({
+const auto enUSSportNames = std::to_array<std::string_view>({
     "American Football",
     "Baseball",
     "Basketball",
@@ -68,6 +82,161 @@ const auto sportNames = std::to_array<std::string_view>({
     "Table Tennis",
     "Tennis",
     "Volleyball",
+});
+
+const SportDefinition enUSSportDefinition = {.femaleAthletes = enUsFemaleAthletes,
+                                             .maleAthletes = enUSMaleAthletes,
+                                             .soccerTeams = enUSSoccerTeams,
+                                             .sportEvents = enUSSportEvents,
+                                             .sportNames = enUSSportNames};
+
+//"es_AR"
+
+const auto esARFemaleAthletes = std::to_array<std::string_view>({
+    "Gabriela Sabatini",
+    "Gisela Dulko",
+    "Paula Pareto",
+    "Luciana Aymar",
+    "Georgina Bardach",
+    "Sabrina Ameghino",
+    "Noemí Simonetto",
+    "Micaela Retegui",
+    "Cecilia Carranza Saroli",
+    "Vanina Onetto",
+});
+
+const auto esARMaleAthletes = std::to_array<std::string_view>({
+    "Emanuel Ginóbili",
+    "Lionel Messi",
+    "Diego Maradona",
+    "Carlos Monzón",
+    "Guillermo Vilas",
+    "Carlos Reutemann",
+    "Nicolino Locche",
+    "Carlos Teves",
+    "Walter Pérez",
+    "Sebastián Crismanich",
+});
+
+const auto esARSoccerTeams = std::to_array<std::string_view>({
+    "Boca Juniors",
+    "River Plate",
+    "Colon Santa Fe",
+    "Independiente",
+    "Rosario Central",
+    "Racing",
+    "San Lorenzo",
+    "Newels Old Boys",
+    "Velez Sarfield",
+    "Talleres",
+});
+
+const auto esARSportEvents = std::to_array<std::string_view>({
+    "Superliga",
+    "Copa Argentina",
+    "Primera B Nacional",
+    "Liga Nacional de Basquet",
+    "Turismo Carretera",
+    "Copa Libertadores",
+    "Liga de Voley Argentina",
+    "Argentina Open Tennis",
+    "Juegos Argentinos de Alto Rendimiento",
+    "MotoGP",
+});
+
+const auto esARSportNames = std::to_array<std::string_view>({
+    "Futbol",
+    "Baseball",
+    "Basquet",
+    "Cricket",
+    "Golf",
+    "Rugby",
+    "Polo",
+    "Ping Pong",
+    "Tenis",
+    "Voley",
+});
+
+const SportDefinition esARSportDefinition = {.femaleAthletes = esARFemaleAthletes,
+                                             .maleAthletes = esARMaleAthletes,
+                                             .soccerTeams = esARSoccerTeams,
+                                             .sportEvents = esARSportEvents,
+                                             .sportNames = esARSportNames};
+
+//"pt-br"
+
+const auto ptBRFemaleAthletes = std::to_array<std::string_view>({
+    "Amanda Nunes",
+    "Natahsa Ferreira",
+    "Paula Pareto",
+    "Larissa França",
+    "Juliana Veloso",
+    "Leticia Santos",
+    "Sissi",
+    "Thaísa",
+    "Marta Vieira",
+});
+
+const auto ptBRMaleAthletes = std::to_array<std::string_view>({
+    "Pele",
+    "Ayrton Senna",
+    "Nelson Piquet",
+    "Ronaldo",
+    "Ronaldinho",
+    "Guga Kuerten",
+    "Kaka",
+    "Neymar",
+    "Garrincha",
+    "Socrates",
+});
+
+const auto ptBRSoccerTeams = std::to_array<std::string_view>({
+    "Sao Paulo",
+    "Flamengo",
+    "Inter Porto Alegre",
+    "Santos",
+    "Cruzeiro",
+    "Corinthians",
+    "Gremio",
+    "Atletico Mineiro",
+    "Vasco da Gamma",
+    "Botafogo",
+});
+
+const auto ptBRSportEvents = std::to_array<std::string_view>({
+    "Brasileirao",
+    "Campeonato Paulista",
+    "Copa Brasil",
+    "GP Interlagos",
+    "ATP 500 Rio de Janeiro",
+    "ATP 250 Sao Paulo",
+    "Libertadores de América",
+    "MotoGP Rio do Janeiro",
+});
+
+const auto ptBRSportNames = std::to_array<std::string_view>({
+    "Futebol",
+    "Handebol",
+    "Tênis",
+    "boxe",
+    "Golf",
+    "rúgbi",
+    "Polo",
+    "Natação",
+    "Artes marciais",
+    "Voleibol",
+});
+
+const SportDefinition ptBRSportDefinition = {.femaleAthletes = ptBRFemaleAthletes,
+                                             .maleAthletes = ptBRMaleAthletes,
+                                             .soccerTeams = ptBRSoccerTeams,
+                                             .sportEvents = ptBRSportEvents,
+                                             .sportNames = ptBRSportNames};
+
+const std::map<faker::Locale, const SportDefinition> sportMapSpan({
+    {faker::Locale::en_US, {enUSSportDefinition}},
+    {faker::Locale::es_AR, {esARSportDefinition}},
+    {faker::Locale::pt_BR, {ptBRSportDefinition}},
 });
 
 }

--- a/tests/modules/internet_test.cpp
+++ b/tests/modules/internet_test.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <chrono>
 
 #include "gtest/gtest.h"
 

--- a/tests/modules/sport_test.cpp
+++ b/tests/modules/sport_test.cpp
@@ -5,52 +5,85 @@
 
 #include "faker-cxx/sport.h"
 #include "sport_data.h"
+#include "locale.h"
 
 using namespace ::testing;
 using namespace faker;
 using namespace faker::sport;
 
-class SportTest : public Test
+
+namespace
+{
+
+const struct SportDefinition& getSportMapDefinition(Locale locale)
+{
+    if (sportMapSpan.find(locale) == sportMapSpan.end())
+    {
+        return sportMapSpan.at(Locale::en_US);
+    }
+    else
+    {
+        return sportMapSpan.at(locale);
+    }
+}
+}
+
+class SportTestLocale : public TestWithParam<Locale>
 {
 public:
 };
 
-TEST_F(SportTest, shouldGenerateSport)
+TEST_P(SportTestLocale, shouldGenerateSportLocale)
 {
-    const auto generatedSport = sportName();
+    auto extra = GetParam();
+    auto sportDefinition = getSportMapDefinition(extra);
+    const auto generatedSport = faker::sport::sportName(extra);
+    
 
-    ASSERT_TRUE(std::ranges::any_of(sportNames, [generatedSport](const std::string_view& sport)
+    ASSERT_TRUE(std::ranges::any_of(sportDefinition.sportNames, [generatedSport](const std::string_view& sport)
                                     { return sport == generatedSport; }));
 }
-
-TEST_F(SportTest, shouldGenerateSoccerTeam)
+TEST_P(SportTestLocale, shouldGenerateFemaleAthleteLocale)
 {
-    const auto generatedSoccerTeam = soccerTeam();
+    auto extra = GetParam();
+    auto sportDefinition = getSportMapDefinition(extra);
 
-    ASSERT_TRUE(std::ranges::any_of(soccerTeams, [generatedSoccerTeam](const std::string_view& soccerTeam)
-                                    { return soccerTeam == generatedSoccerTeam; }));
+    const auto generatedFemaleAthlete = femaleAthlete(extra);
+
+    ASSERT_TRUE(std::ranges::any_of(sportDefinition.femaleAthletes, [generatedFemaleAthlete](const std::string_view& femaleAthlete)
+                                    { return femaleAthlete == generatedFemaleAthlete; }));
 }
+TEST_P(SportTestLocale, shouldGenerateMaleAthleteLocale)
+{    
+    auto extra = GetParam();
+    auto sportDefinition = getSportMapDefinition(extra);
+    const auto generatedMaleAthlete = maleAthlete(extra);
 
-TEST_F(SportTest, shouldGenerateSportEvent)
-{
-    const auto generatedSportEvent = sportEvent();
-
-    ASSERT_TRUE(std::ranges::any_of(sportEvents, [generatedSportEvent](const std::string_view& sportEvent)
-                                    { return sportEvent == generatedSportEvent; }));
-}
-
-TEST_F(SportTest, shouldGenerateMaleAthlete)
-{
-    const auto generatedMaleAthlete = maleAthlete();
-
-    ASSERT_TRUE(std::ranges::any_of(maleAthletes, [generatedMaleAthlete](const std::string_view& maleAthlete)
+    ASSERT_TRUE(std::ranges::any_of(sportDefinition.maleAthletes, [generatedMaleAthlete](const std::string_view& maleAthlete)
                                     { return maleAthlete == generatedMaleAthlete; }));
 }
 
-TEST_F(SportTest, shouldGenerateFemaleAthlete)
-{
-    const auto generatedFemaleAthlete = femaleAthlete();
 
-    ASSERT_TRUE(std::ranges::any_of(femaleAthletes, [generatedFemaleAthlete](const std::string_view& femaleAthlete)
-                                    { return femaleAthlete == generatedFemaleAthlete; }));
+TEST_P(SportTestLocale, shouldGenerateSoccerTeamLocale)
+{
+    auto extra = GetParam();
+    auto sportDefinition = getSportMapDefinition(extra);
+    const auto generatedSoccerTeam = soccerTeam(extra);
+
+    ASSERT_TRUE(std::ranges::any_of(sportDefinition.soccerTeams, [generatedSoccerTeam](const std::string_view& soccerTeam)
+                                    { return soccerTeam == generatedSoccerTeam; }));
 }
+
+TEST_P(SportTestLocale, shouldGenerateSportEventLocale)
+{
+    auto extra = GetParam();
+    auto sportDefinition = getSportMapDefinition(extra);
+    const auto generatedSportEvent = sportEvent(extra);
+
+    ASSERT_TRUE(std::ranges::any_of(sportDefinition.sportEvents, [generatedSportEvent](const std::string_view& sportEvent)
+                                    { return sportEvent == generatedSportEvent; }));
+}
+
+
+INSTANTIATE_TEST_SUITE_P(testSportByLocale, SportTestLocale, ValuesIn(locales),
+                         [](const TestParamInfo<Locale>& paramInfo) { return toString(paramInfo.param); });


### PR DESCRIPTION
<!-- Please run build and tests before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md#committing -->

Just add locale functionality to the sport module with 2 more groups of elements: es_AR and pt_BR. The functions map to en_US with the original data by default.
fix issue [https://github.com/cieslarmichal/faker-cxx/issues/897#top](https://github.com/cieslarmichal/faker-cxx/issues/897#top)