### PR TITLE
fix: fix imageUrl in Image module to generate images from picsum photos #990

### DIFF
--- a/include/faker-cxx/image.h
+++ b/include/faker-cxx/image.h
@@ -34,13 +34,33 @@ enum class ImageCategory
  * @returns Random real image url from external service.
  *
  * @code
- * faker::image::imageUrl() // "https://loremflickr.com/640/480"
- * faker::image::imageUrl(800, 600) // "https://loremflickr.com/800/600"
- * faker::image::imageUrl(800, 600, ImageCategory::Animals) // "https://loremflickr.com/800/600/animals"
+ * faker::image::urlLoremFlickr() // "https://loremflickr.com/640/480"
+ * faker::image::urlLoremFlickr(800, 600) // "https://loremflickr.com/800/600"
+ * faker::image::urlLoremFlickr(800, 600, ImageCategory::Animals) // "https://loremflickr.com/800/600/animals"
  * @endcode
  */
-FAKER_CXX_EXPORT std::string imageUrl(unsigned width = 640, unsigned height = 480,
+FAKER_CXX_EXPORT std::string urlLoremFlickr(unsigned width = 640, unsigned height = 480,
                                       std::optional<ImageCategory> category = std::nullopt);
+
+/**
+ * @brief Generates a real image url with "https://picsum.photos" .
+ *
+ * @param width The width of the image. Defaults to `640`.
+ * @param height The height of the image. Defaults to `480`.
+ * @param greyscale The optional greyscale filter. True for apply or false for disabled
+ * @param blur The optional blur effect between 1 and 10
+ *
+ * @returns Random real image url from external service
+ *
+ * @code
+ * faker::image::urlPicsPhotos() // "https://picsum.photos/640/480"
+ * faker::image::urlPicsPhotos(800,600,true) // "https://picsum.photos/800/600?grayscale
+ * faker::image::urlPicsPhotos(800,600,false,5) // "https://picsum.photos/800/600?blur=5
+ * faker::image::urlPicsPhotos(800,600,true,1) // "https://picsum.photos/800/600?grayscale&blur=1
+ *@endcode
+ */
+FAKER_CXX_EXPORT std::string urlPicsumPhotos(unsigned width = 640, unsigned height = 480,
+                                           std::optional<bool> greyscale = std::nullopt, std::optional<int> blur = std::nullopt);
 
 /**
  * @brief Generates a random avatar from GitHub.
@@ -71,6 +91,7 @@ FAKER_CXX_EXPORT std::string dimensions();
  *
  * @code
  * faker::image::type() // "png"
+ * @endcode
  */
 FAKER_CXX_EXPORT std::string_view type();
 }

--- a/include/faker-cxx/image.h
+++ b/include/faker-cxx/image.h
@@ -54,7 +54,7 @@ FAKER_CXX_EXPORT std::string imageUrl(unsigned width = 640, unsigned height = 48
  * @endcode
  */
 FAKER_CXX_EXPORT std::string urlLoremFlickr(unsigned width = 640, unsigned height = 480,
-                                      std::optional<ImageCategory> category = std::nullopt);
+                                            std::optional<ImageCategory> category = std::nullopt);
 
 /**
  * @brief Generates a real image url with "https://picsum.photos" .

--- a/include/faker-cxx/image.h
+++ b/include/faker-cxx/image.h
@@ -25,6 +25,20 @@ enum class ImageCategory
 };
 
 /**
+ * @brief Generates a random image url with `https://loremflickr.com/` or "https://picsum.photos".
+ *
+ * @param width The width of the image. Defaults to `640`.
+ * @param height The height of the image. Defaults to `480`.
+ *
+ * @returns Random real image url from external service.
+ *
+ * @code
+ * faker::image::imageUrl() // "https://loremflickr.com/640/480" or "https://picsum.photos/640/480"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string imageUrl(unsigned width = 640, unsigned height = 480);
+
+/**
  * @brief Generates a real image url with `https://loremflickr.com/`.
  *
  * @param width The width of the image. Defaults to `640`.
@@ -60,7 +74,8 @@ FAKER_CXX_EXPORT std::string urlLoremFlickr(unsigned width = 640, unsigned heigh
  *@endcode
  */
 FAKER_CXX_EXPORT std::string urlPicsumPhotos(unsigned width = 640, unsigned height = 480,
-                                           std::optional<bool> greyscale = std::nullopt, std::optional<int> blur = std::nullopt);
+                                             std::optional<bool> greyscale = std::nullopt,
+                                             std::optional<int> blur = std::nullopt);
 
 /**
  * @brief Generates a random avatar from GitHub.

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -25,12 +25,34 @@ std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringM
 };
 }
 
-std::string imageUrl(unsigned int width, unsigned int height, std::optional<ImageCategory> category)
+std::string urlLoremFlickr(unsigned int width, unsigned int height, std::optional<ImageCategory> category)
 {
     const std::string image_category =
         category.has_value() ? common::format("/{}", imageCategoryToLoremFlickrStringMapping.at(category.value())) : "";
 
     return common::format("https://loremflickr.com/{}/{}{}", width, height, image_category);
+}
+
+std::string urlPicsumPhotos(unsigned width, unsigned height, const std::optional<bool> greyscale, const std::optional<int> blur)
+{
+    std::string url = common::format("https://picsum.photos/{}/{}", width, height);
+    std::string params;
+
+    params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
+
+    if(blur.has_value())
+    {
+        if(blur.value() < 1 || blur.value() > 10 )
+            return common::format("{}","Error: blur must be between 1 and 10.");
+        if (!params.empty())
+            params += "&";
+        params += common::format("blur={}", blur.value());
+    }
+    if(!params.empty())
+    {
+        url = common::format("{}?{}", url, params);
+    }
+    return common::format("{}",url);
 }
 
 std::string githubAvatarUrl()

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -1,6 +1,7 @@
 #include "faker-cxx/image.h"
 
 #include <array>
+#include <faker-cxx/datatype.h>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -25,6 +26,16 @@ std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringM
 };
 }
 
+std::string imageUrl(unsigned width, unsigned height)
+{
+    if (faker::datatype::boolean(0.5))
+    {
+        return urlLoremFlickr();
+    }
+    else
+        return urlPicsumPhotos();
+}
+
 std::string urlLoremFlickr(unsigned int width, unsigned int height, std::optional<ImageCategory> category)
 {
     const std::string image_category =
@@ -33,26 +44,27 @@ std::string urlLoremFlickr(unsigned int width, unsigned int height, std::optiona
     return common::format("https://loremflickr.com/{}/{}{}", width, height, image_category);
 }
 
-std::string urlPicsumPhotos(unsigned width, unsigned height, const std::optional<bool> greyscale, const std::optional<int> blur)
+std::string urlPicsumPhotos(unsigned width, unsigned height, const std::optional<bool> greyscale,
+                            const std::optional<int> blur)
 {
     std::string url = common::format("https://picsum.photos/{}/{}", width, height);
     std::string params;
 
     params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
 
-    if(blur.has_value())
+    if (blur.has_value())
     {
-        if(blur.value() < 1 || blur.value() > 10 )
-            return common::format("{}","Error: blur must be between 1 and 10.");
+        if (blur.value() < 1 || blur.value() > 10)
+            return common::format("{}", "Error: blur must be between 1 and 10.");
         if (!params.empty())
             params += "&";
         params += common::format("blur={}", blur.value());
     }
-    if(!params.empty())
+    if (!params.empty())
     {
         url = common::format("{}?{}", url, params);
     }
-    return common::format("{}",url);
+    return common::format("{}", url);
 }
 
 std::string githubAvatarUrl()

--- a/tests/modules/image_test.cpp
+++ b/tests/modules/image_test.cpp
@@ -17,9 +17,9 @@ class ImageTest : public Test
 public:
 };
 
-TEST_F(ImageTest, shouldGenerateImageUrlDefault)
+TEST_F(ImageTest, shouldGenerateurlLoremFlickrDefault)
 {
-    const auto generatedImageUrl = imageUrl();
+    const auto generatedImageUrl = urlLoremFlickr();
 
     ASSERT_EQ(generatedImageUrl, "https://loremflickr.com/640/480");
 }
@@ -29,20 +29,72 @@ TEST_F(ImageTest, shouldGenerateImageUrl)
     const auto width = 800;
     const auto height = 600;
 
-    const auto generatedImageUrl = imageUrl(width, height);
+    const auto generatedImageUrl = urlLoremFlickr(width, height);
 
     ASSERT_EQ(generatedImageUrl, "https://loremflickr.com/800/600");
 }
 
-TEST_F(ImageTest, shouldGenerateImageUrlCategory)
+TEST_F(ImageTest, shouldGenerateurlLoremFlickrCategory)
 {
     const auto width = 800;
     const auto height = 600;
     const auto category = ImageCategory::Fashion;
 
-    const auto generatedImageUrl = imageUrl(width, height, category);
+    const auto generatedImageUrl = urlLoremFlickr(width, height, category);
 
     ASSERT_EQ(generatedImageUrl, "https://loremflickr.com/800/600/fashion");
+}
+
+TEST_F(ImageTest, shouldGenerateImageUrlPicsumDefault)
+{
+    const auto generatedImageUrl = urlPicsumPhotos();
+
+    ASSERT_EQ(generatedImageUrl, "https://picsum.photos/640/480");
+}
+
+TEST_F(ImageTest, shouldGenerateImageUrlPicsumPhotos)
+{
+    const auto width = 800;
+    const auto height = 600;
+
+    const auto generatedImageUrl = urlPicsumPhotos(width, height);
+
+    ASSERT_EQ(generatedImageUrl, "https://picsum.photos/800/600");
+}
+
+TEST_F(ImageTest, shouldGenerateImageUrlPicsumPhotosGreyscale)
+{
+    const auto width = 800;
+    const auto height = 600;
+    const auto greyscale = true;
+
+    const auto generatedImageUrl = urlPicsumPhotos(width, height, greyscale);
+
+    ASSERT_EQ(generatedImageUrl, "https://picsum.photos/800/600?greyscale");
+}
+
+TEST_F(ImageTest, shouldGenerateImageUrlPicsumPhotosBlur)
+{
+    const auto width = 800;
+    const auto height = 600;
+    const auto greyscale = false;
+    const auto blur = 5;
+
+    const auto generatedImageUrl = urlPicsumPhotos(width, height, greyscale, blur);
+
+    ASSERT_EQ(generatedImageUrl, "https://picsum.photos/800/600?blur=5");
+}
+
+TEST_F(ImageTest, shouldGenerateImageUrlPicsumPhotosBlurandGreyscale)
+{
+    const auto width = 800;
+    const auto height = 600;
+    const auto greyscale = true;
+    const auto blur = 6;
+
+    const auto generatedImageUrl = urlPicsumPhotos(width, height, greyscale, blur);
+
+    ASSERT_EQ(generatedImageUrl, "https://picsum.photos/800/600?greyscale&blur=6");
 }
 
 TEST_F(ImageTest, shouldGenerateGithubAvatarUrl)

--- a/tests/modules/image_test.cpp
+++ b/tests/modules/image_test.cpp
@@ -17,6 +17,13 @@ class ImageTest : public Test
 public:
 };
 
+TEST_F(ImageTest, shouldGenerateRandomImageUrl)
+{
+    const auto generatedImageUrl = imageUrl();
+
+    ASSERT_TRUE(generatedImageUrl == urlLoremFlickr() || generatedImageUrl == urlPicsumPhotos());
+}
+
 TEST_F(ImageTest, shouldGenerateurlLoremFlickrDefault)
 {
     const auto generatedImageUrl = urlLoremFlickr();


### PR DESCRIPTION

Summary of changes:

- Added a new method urlPicsumPhotos() to generate random images from the  https://picsum.photos website.
- Created necessary tests to ensure proper functionality.
- Renamed the imageUrl() method in urlLoremFlickr() to better distinguish between the different websites used for image generation. 