### PR TITLE
feat: Implement dataUri function for SVG generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,10 @@ endif ()
 
 cmake_dependent_option(USE_STD_FORMAT "Use std::format when available" ON "HAS_STD_FORMAT" OFF)
 
-add_library(${PROJECT_NAME})
+add_library(${PROJECT_NAME}
+    src/modules/image.cpp
+    src/modules/base64.cpp
+)
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(faker-cxx
     LANGUAGES CXX
-    VERSION 3.0.0
+    VERSION 4.0.1
     DESCRIPTION "C++ Faker library for generating fake (but realistic) data."
     HOMEPAGE_URL "https://github.com/cieslarmichal/faker-cxx")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(faker-cxx
     LANGUAGES CXX
-    VERSION 4.0.1
+    VERSION 3.0.0
     DESCRIPTION "C++ Faker library for generating fake (but realistic) data."
     HOMEPAGE_URL "https://github.com/cieslarmichal/faker-cxx")
 
@@ -22,10 +22,7 @@ endif ()
 
 cmake_dependent_option(USE_STD_FORMAT "Use std::format when available" ON "HAS_STD_FORMAT" OFF)
 
-add_library(${PROJECT_NAME}
-    src/modules/image.cpp
-    src/modules/base64.cpp
-)
+add_library(${PROJECT_NAME})
 
 add_subdirectory(src)
 

--- a/include/faker-cxx/base64.h
+++ b/include/faker-cxx/base64.h
@@ -1,0 +1,11 @@
+#ifndef BASE64_H
+#define BASE64_H
+
+#include <string>
+
+namespace base64 {
+    std::string encode(const std::string &input);
+    std::string decode(const void* data, const size_t len);
+}
+
+#endif

--- a/include/faker-cxx/base64.h
+++ b/include/faker-cxx/base64.h
@@ -1,5 +1,4 @@
-#ifndef BASE64_H
-#define BASE64_H
+#pragma once
 
 #include <string>
 
@@ -7,5 +6,3 @@ namespace faker::base64 {
     std::string encode(const std::string &input);
     std::string decode(const void* data, const size_t len);
 }
-
-#endif

--- a/include/faker-cxx/base64.h
+++ b/include/faker-cxx/base64.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace base64 {
+namespace faker::base64 {
     std::string encode(const std::string &input);
     std::string decode(const void* data, const size_t len);
 }

--- a/include/faker-cxx/base64.h
+++ b/include/faker-cxx/base64.h
@@ -2,7 +2,8 @@
 
 #include <string>
 
-namespace faker::base64 {
-    std::string encode(const std::string &input);
-    std::string decode(const void* data, const size_t len);
+namespace faker::base64
+{
+std::string encode(const std::string& input);
+std::string decode(const void* data, const size_t len);
 }

--- a/include/faker-cxx/image.h
+++ b/include/faker-cxx/image.h
@@ -124,6 +124,7 @@ FAKER_CXX_EXPORT std::string_view type();
  * faker::image::dataUri(200, 200, "000000", "svg-base64") // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3...'
  * @endcode
  */
-FAKER_CXX_EXPORT std::string dataUri(unsigned width = 200, unsigned height = 200, const std::string& color = "000000", const std::string& type = "svg-uri");
+FAKER_CXX_EXPORT std::string dataUri(unsigned width = 200, unsigned height = 200, const std::string& color = "000000",
+                                     const std::string& type = "svg-uri");
 
 }

--- a/include/faker-cxx/image.h
+++ b/include/faker-cxx/image.h
@@ -109,4 +109,21 @@ FAKER_CXX_EXPORT std::string dimensions();
  * @endcode
  */
 FAKER_CXX_EXPORT std::string_view type();
+
+/**
+ * @brief Generates a random data uri containing an URL-encoded SVG image or a Base64-encoded SVG image.
+ *
+ * @param width The width of the image. Defaults to a random number between 1 and 3999.
+ * @param height The height of the image. Defaults to a random number between 1 and 3999.
+ * @param color The color of the image. Must be a color supported by svg.
+ * @param type The type of the image to return. Consisting of the file extension and the used encoding.
+ * @return A string containing the data uri.
+ *
+ * @code
+ * faker::image::dataUri() // 'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http...'
+ * faker::image::dataUri({ type: 'svg-base64' }) // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3...'
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string dataUri(unsigned width = 200, unsigned height = 200, const std::string& color = "000000", const std::string& type = "svg-uri");
+
 }

--- a/include/faker-cxx/image.h
+++ b/include/faker-cxx/image.h
@@ -121,7 +121,7 @@ FAKER_CXX_EXPORT std::string_view type();
  *
  * @code
  * faker::image::dataUri() // 'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http...'
- * faker::image::dataUri({ type: 'svg-base64' }) // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3...'
+ * faker::image::dataUri(200, 200, "000000", "svg-base64") // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3...'
  * @endcode
  */
 FAKER_CXX_EXPORT std::string dataUri(unsigned width = 200, unsigned height = 200, const std::string& color = "000000", const std::string& type = "svg-uri");

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(FAKER_SOURCES
     modules/git.cpp
     modules/hacker.cpp
     modules/helper.cpp
+    modules/base64.cpp
     modules/image.cpp
     modules/internet.cpp
     modules/location.cpp

--- a/src/modules/base64.cpp
+++ b/src/modules/base64.cpp
@@ -1,23 +1,26 @@
 #include "faker-cxx/base64.h"
+
 #include <cstdint>
 
 static const char encodeLookup[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 static const char padCharacter = '=';
-static const int B64index[256] = { 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 62, 63, 62, 62, 63, 52, 53, 54, 55,
-56, 57, 58, 59, 60, 61,  0,  0,  0,  0,  0,  0,  0,  0,  1,  2,  3,  4,  5,  6,
-7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,  0,
-0,  0,  0, 63,  0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51 };
+static const int B64index[256] = {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+                                  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+                                  0,  62, 63, 62, 62, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0,  0,  0,  0,  0,
+                                  0,  0,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                                  19, 20, 21, 22, 23, 24, 25, 0,  0,  0,  0,  63, 0,  26, 27, 28, 29, 30, 31, 32, 33,
+                                  34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
 
-namespace faker::base64 {
-std::string encode(const std::string &input) {
+namespace faker::base64
+{
+std::string encode(const std::string& input)
+{
     std::string encodedString;
     encodedString.reserve(((input.size() / 3) + (input.size() % 3 > 0)) * 4);
     uint32_t temp;
     auto cursor = input.begin();
-    for (size_t idx = 0; idx < input.size() / 3; ++idx) {
+    for (size_t idx = 0; idx < input.size() / 3; ++idx)
+    {
         temp = (*cursor++) << 16;
         temp += (*cursor++) << 8;
         temp += (*cursor++);
@@ -26,7 +29,8 @@ std::string encode(const std::string &input) {
         encodedString.append(1, encodeLookup[(temp & 0x00000FC0) >> 6]);
         encodedString.append(1, encodeLookup[(temp & 0x0000003F)]);
     }
-    switch (input.size() % 3) {
+    switch (input.size() % 3)
+    {
     case 1:
         temp = (*cursor++) << 16;
         encodedString.append(1, encodeLookup[(temp & 0x00FC0000) >> 18]);

--- a/src/modules/base64.cpp
+++ b/src/modules/base64.cpp
@@ -1,4 +1,5 @@
 #include "faker-cxx/base64.h"
+#include <cstdint>
 
 static const char encodeLookup[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 static const char padCharacter = '=';

--- a/src/modules/base64.cpp
+++ b/src/modules/base64.cpp
@@ -10,7 +10,8 @@ static const int B64index[256] = { 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
 0,  0,  0, 63,  0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51 };
 
-std::string base64::encode(const std::string &input) {
+namespace faker::base64 {
+std::string encode(const std::string &input) {
     std::string encodedString;
     encodedString.reserve(((input.size() / 3) + (input.size() % 3 > 0)) * 4);
     uint32_t temp;
@@ -43,7 +44,7 @@ std::string base64::encode(const std::string &input) {
     return encodedString;
 }
 
-std::string base64::decode(const void* data, const size_t len)
+std::string decode(const void* data, const size_t len)
 {
     unsigned char* p = (unsigned char*)data;
     int pad = len > 0 && (len % 4 || p[len - 1] == '=');
@@ -69,4 +70,5 @@ std::string base64::decode(const void* data, const size_t len)
         }
     }
     return str;
+}
 }

--- a/src/modules/base64.cpp
+++ b/src/modules/base64.cpp
@@ -1,0 +1,72 @@
+#include "faker-cxx/base64.h"
+
+static const char encodeLookup[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char padCharacter = '=';
+static const int B64index[256] = { 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 62, 63, 62, 62, 63, 52, 53, 54, 55,
+56, 57, 58, 59, 60, 61,  0,  0,  0,  0,  0,  0,  0,  0,  1,  2,  3,  4,  5,  6,
+7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,  0,
+0,  0,  0, 63,  0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51 };
+
+std::string base64::encode(const std::string &input) {
+    std::string encodedString;
+    encodedString.reserve(((input.size() / 3) + (input.size() % 3 > 0)) * 4);
+    uint32_t temp;
+    auto cursor = input.begin();
+    for (size_t idx = 0; idx < input.size() / 3; ++idx) {
+        temp = (*cursor++) << 16;
+        temp += (*cursor++) << 8;
+        temp += (*cursor++);
+        encodedString.append(1, encodeLookup[(temp & 0x00FC0000) >> 18]);
+        encodedString.append(1, encodeLookup[(temp & 0x0003F000) >> 12]);
+        encodedString.append(1, encodeLookup[(temp & 0x00000FC0) >> 6]);
+        encodedString.append(1, encodeLookup[(temp & 0x0000003F)]);
+    }
+    switch (input.size() % 3) {
+    case 1:
+        temp = (*cursor++) << 16;
+        encodedString.append(1, encodeLookup[(temp & 0x00FC0000) >> 18]);
+        encodedString.append(1, encodeLookup[(temp & 0x0003F000) >> 12]);
+        encodedString.append(2, padCharacter);
+        break;
+    case 2:
+        temp = (*cursor++) << 16;
+        temp += (*cursor++) << 8;
+        encodedString.append(1, encodeLookup[(temp & 0x00FC0000) >> 18]);
+        encodedString.append(1, encodeLookup[(temp & 0x0003F000) >> 12]);
+        encodedString.append(1, encodeLookup[(temp & 0x00000FC0) >> 6]);
+        encodedString.append(1, padCharacter);
+        break;
+    }
+    return encodedString;
+}
+
+std::string base64::decode(const void* data, const size_t len)
+{
+    unsigned char* p = (unsigned char*)data;
+    int pad = len > 0 && (len % 4 || p[len - 1] == '=');
+    const size_t L = ((len + 3) / 4 - pad) * 4;
+    std::string str(L / 4 * 3 + pad, '\0');
+
+    for (size_t i = 0, j = 0; i < L; i += 4)
+    {
+        int n = B64index[p[i]] << 18 | B64index[p[i + 1]] << 12 | B64index[p[i + 2]] << 6 | B64index[p[i + 3]];
+        str[j++] = n >> 16;
+        str[j++] = n >> 8 & 0xFF;
+        str[j++] = n & 0xFF;
+    }
+    if (pad)
+    {
+        int n = B64index[p[L]] << 18 | B64index[p[L + 1]] << 12;
+        str[str.size() - 1] = n >> 16;
+
+        if (len > L + 2 && p[L + 2] != '=')
+        {
+            n |= B64index[p[L + 2]] << 6;
+            str.push_back(n >> 8 & 0xFF);
+        }
+    }
+    return str;
+}

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -106,8 +106,8 @@ std::string dataUri(unsigned width, unsigned height, const std::string& color, c
               << "width=\"" << width << "\" height=\"" << height << "\">"
               << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
               << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
-              << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">" << width
-              << "x" << height << "</text></svg>";
+              << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">" 
+              << width << "x" << height << "</text></svg>";
 
     const auto svgString = svgStream.str();
 

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -3,14 +3,15 @@
 #include <array>
 #include <faker-cxx/datatype.h>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <sstream>
+
 #include "common/format_helper.h"
+#include "faker-cxx/base64.h"
 #include "faker-cxx/helper.h"
 #include "faker-cxx/number.h"
-#include "faker-cxx/base64.h"
 
 namespace faker::image
 {
@@ -26,9 +27,9 @@ std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringM
     {ImageCategory::Sports, "sports"},   {ImageCategory::Technics, "technics"}, {ImageCategory::Transport, "transport"},
 };
 
-std::string randomColor() {
-    return "rgb(" + std::to_string(number::integer(0, 255)) + "," +
-           std::to_string(number::integer(0, 255)) + "," +
+std::string randomColor()
+{
+    return "rgb(" + std::to_string(number::integer(0, 255)) + "," + std::to_string(number::integer(0, 255)) + "," +
            std::to_string(number::integer(0, 255)) + ")";
 }
 
@@ -98,22 +99,28 @@ std::string_view type()
     return helper::randomElement(imageTypes);
 }
 
-std::string dataUri(unsigned width, unsigned height, const std::string &color, const std::string &type) {
+std::string dataUri(unsigned width, unsigned height, const std::string& color, const std::string& type)
+{
     std::ostringstream svgStream;
     svgStream << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" baseProfile=\"full\" "
               << "width=\"" << width << "\" height=\"" << height << "\">"
               << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
-              << "<text x=\"" << width / 2 << "\" y=\"" << height / 2 
-              << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">"
-              << width << "x" << height << "</text></svg>";
+              << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
+              << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">" << width
+              << "x" << height << "</text></svg>";
 
     const auto svgString = svgStream.str();
 
-    if (type == "svg-uri") {
+    if (type == "svg-uri")
+    {
         return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);
-    } else if (type == "svg-base64") {
-        return "data:image/svg+xml;base64," + base64::encode(svgString); 
-    } else {
+    }
+    else if (type == "svg-base64")
+    {
+        return "data:image/svg+xml;base64," + base64::encode(svgString);
+    }
+    else
+    {
         throw std::invalid_argument("Invalid type specified. Use 'svg-uri' or 'svg-base64'.");
     }
 }

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -13,115 +13,117 @@
 #include "faker-cxx/helper.h"
 #include "faker-cxx/number.h"
 
-namespace faker::image
-{
-namespace
-{
-const std::array<std::string_view, 15> imageTypes = {"ai",  "bmp", "eps", "gif", "heif", "indd", "jpeg", "jpg",
-                                                     "pdf", "png", "psd", "raw", "svg",  "tiff", "webp"};
+namespace faker::image {
+namespace {
+const std::array<std::string_view, 15> imageTypes = {
+    "ai",  "bmp", "eps", "gif", "heif", "indd", "jpeg", "jpg",
+    "pdf", "png", "psd", "raw", "svg",  "tiff", "webp"};
 
-std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringMapping = {
-    {ImageCategory::Animals, "animals"}, {ImageCategory::Business, "business"}, {ImageCategory::Cats, "cats"},
-    {ImageCategory::City, "city"},       {ImageCategory::Food, "food"},         {ImageCategory::Nightlife, "nightlife"},
-    {ImageCategory::Fashion, "fashion"}, {ImageCategory::People, "people"},     {ImageCategory::Nature, "nature"},
-    {ImageCategory::Sports, "sports"},   {ImageCategory::Technics, "technics"}, {ImageCategory::Transport, "transport"},
+std::unordered_map<ImageCategory, std::string>
+    imageCategoryToLoremFlickrStringMapping = {
+        {ImageCategory::Animals, "animals"},
+        {ImageCategory::Business, "business"},
+        {ImageCategory::Cats, "cats"},
+        {ImageCategory::City, "city"},
+        {ImageCategory::Food, "food"},
+        {ImageCategory::Nightlife, "nightlife"},
+        {ImageCategory::Fashion, "fashion"},
+        {ImageCategory::People, "people"},
+        {ImageCategory::Nature, "nature"},
+        {ImageCategory::Sports, "sports"},
+        {ImageCategory::Technics, "technics"},
+        {ImageCategory::Transport, "transport"},
 };
 
-std::string randomColor()
-{
-    return "rgb(" + std::to_string(number::integer(0, 255)) + "," + std::to_string(number::integer(0, 255)) + "," +
-           std::to_string(number::integer(0, 255)) + ")";
+std::string randomColor() {
+  return "rgb(" + std::to_string(number::integer(0, 255)) + "," +
+         std::to_string(number::integer(0, 255)) + "," +
+         std::to_string(number::integer(0, 255)) + ")";
 }
 
+} // namespace
+
+std::string imageUrl(unsigned width, unsigned height) {
+  if (faker::datatype::boolean(0.5)) {
+    return urlLoremFlickr(width, height);
+  }
+
+  return urlPicsumPhotos(width, height);
 }
 
-std::string imageUrl(unsigned width, unsigned height)
-{
-    if (faker::datatype::boolean(0.5))
-    {
-        return urlLoremFlickr(width, height);
+std::string urlLoremFlickr(unsigned int width, unsigned int height,
+                           std::optional<ImageCategory> category) {
+  const std::string image_category =
+      category.has_value()
+          ? common::format("/{}", imageCategoryToLoremFlickrStringMapping.at(
+                                      category.value()))
+          : "";
+
+  return common::format("https://loremflickr.com/{}/{}{}", width, height,
+                        image_category);
+}
+
+std::string urlPicsumPhotos(unsigned width, unsigned height,
+                            const std::optional<bool> greyscale,
+                            const std::optional<int> blur) {
+  std::string url =
+      common::format("https://picsum.photos/{}/{}", width, height);
+  std::string params;
+
+  params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
+
+  if (blur.has_value()) {
+    if (blur.value() < 1 || blur.value() > 10) {
+      throw std::invalid_argument("Blur must be between 1 and 10");
     }
 
-    return urlPicsumPhotos(width, height);
-}
-
-std::string urlLoremFlickr(unsigned int width, unsigned int height, std::optional<ImageCategory> category)
-{
-    const std::string image_category =
-        category.has_value() ? common::format("/{}", imageCategoryToLoremFlickrStringMapping.at(category.value())) : "";
-
-    return common::format("https://loremflickr.com/{}/{}{}", width, height, image_category);
-}
-
-std::string urlPicsumPhotos(unsigned width, unsigned height, const std::optional<bool> greyscale,
-                            const std::optional<int> blur)
-{
-    std::string url = common::format("https://picsum.photos/{}/{}", width, height);
-    std::string params;
-
-    params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
-
-    if (blur.has_value())
-    {
-        if (blur.value() < 1 || blur.value() > 10)
-        {
-            throw std::invalid_argument("Blur must be between 1 and 10");
-        }
-
-        if (!params.empty())
-        {
-            params += "&";
-        }
-
-        params += common::format("blur={}", blur.value());
+    if (!params.empty()) {
+      params += "&";
     }
 
-    if (!params.empty())
-    {
-        url = common::format("{}?{}", url, params);
-    }
+    params += common::format("blur={}", blur.value());
+  }
 
-    return common::format("{}", url);
+  if (!params.empty()) {
+    url = common::format("{}?{}", url, params);
+  }
+
+  return common::format("{}", url);
 }
 
-std::string githubAvatarUrl()
-{
-    return common::format("https://avatars.githubusercontent.com/u/{}", number::integer<int>(100000000));
+std::string githubAvatarUrl() {
+  return common::format("https://avatars.githubusercontent.com/u/{}",
+                        number::integer<int>(100000000));
 }
 
-std::string dimensions()
-{
-    return common::format("{}x{}", number::integer<int>(1, 32720), number::integer<int>(1, 17280));
+std::string dimensions() {
+  return common::format("{}x{}", number::integer<int>(1, 32720),
+                        number::integer<int>(1, 17280));
 }
 
-std::string_view type()
-{
-    return helper::randomElement(imageTypes);
-}
+std::string_view type() { return helper::randomElement(imageTypes); }
 
-std::string dataUri(unsigned width, unsigned height, const std::string& color, const std::string& type)
-{
-    std::ostringstream svgStream;
-    svgStream << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" baseProfile=\"full\" "
-              << "width=\"" << width << "\" height=\"" << height << "\">"
-              << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
-              << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
-              << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">" 
-              << width << "x" << height << "</text></svg>";
+std::string dataUri(unsigned width, unsigned height, const std::string &color,
+                    const std::string &type) {
+  std::ostringstream svgStream;
+  svgStream << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" "
+               "baseProfile=\"full\" "
+            << "width=\"" << width << "\" height=\"" << height << "\">"
+            << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
+            << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
+            << "\" font-size=\"20\" alignment-baseline=\"middle\" "
+               "text-anchor=\"middle\" fill=\"white\">"
+            << width << "x" << height << "</text></svg>";
 
-    const auto svgString = svgStream.str();
+  const auto svgString = svgStream.str();
 
-    if (type == "svg-uri")
-    {
-        return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);
-    }
-    else if (type == "svg-base64")
-    {
-        return "data:image/svg+xml;base64," + base64::encode(svgString);
-    }
-    else
-    {
-        throw std::invalid_argument("Invalid type specified. Use 'svg-uri' or 'svg-base64'.");
-    }
+  if (type == "svg-uri") {
+    return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);
+  } else if (type == "svg-base64") {
+    return "data:image/svg+xml;base64," + base64::encode(svgString);
+  } else {
+    throw std::invalid_argument(
+        "Invalid type specified. Use 'svg-uri' or 'svg-base64'.");
+  }
 }
-}
+} // namespace faker::image

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -13,117 +13,115 @@
 #include "faker-cxx/helper.h"
 #include "faker-cxx/number.h"
 
-namespace faker::image {
-namespace {
-const std::array<std::string_view, 15> imageTypes = {
-    "ai",  "bmp", "eps", "gif", "heif", "indd", "jpeg", "jpg",
-    "pdf", "png", "psd", "raw", "svg",  "tiff", "webp"};
+namespace faker::image
+{
+namespace
+{
+const std::array<std::string_view, 15> imageTypes = {"ai",  "bmp", "eps", "gif", "heif", "indd", "jpeg", "jpg",
+                                                     "pdf", "png", "psd", "raw", "svg",  "tiff", "webp"};
 
-std::unordered_map<ImageCategory, std::string>
-    imageCategoryToLoremFlickrStringMapping = {
-        {ImageCategory::Animals, "animals"},
-        {ImageCategory::Business, "business"},
-        {ImageCategory::Cats, "cats"},
-        {ImageCategory::City, "city"},
-        {ImageCategory::Food, "food"},
-        {ImageCategory::Nightlife, "nightlife"},
-        {ImageCategory::Fashion, "fashion"},
-        {ImageCategory::People, "people"},
-        {ImageCategory::Nature, "nature"},
-        {ImageCategory::Sports, "sports"},
-        {ImageCategory::Technics, "technics"},
-        {ImageCategory::Transport, "transport"},
+std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringMapping = {
+    {ImageCategory::Animals, "animals"}, {ImageCategory::Business, "business"}, {ImageCategory::Cats, "cats"},
+    {ImageCategory::City, "city"},       {ImageCategory::Food, "food"},         {ImageCategory::Nightlife, "nightlife"},
+    {ImageCategory::Fashion, "fashion"}, {ImageCategory::People, "people"},     {ImageCategory::Nature, "nature"},
+    {ImageCategory::Sports, "sports"},   {ImageCategory::Technics, "technics"}, {ImageCategory::Transport, "transport"},
 };
 
-std::string randomColor() {
-  return "rgb(" + std::to_string(number::integer(0, 255)) + "," +
-         std::to_string(number::integer(0, 255)) + "," +
-         std::to_string(number::integer(0, 255)) + ")";
+std::string randomColor()
+{
+    return "rgb(" + std::to_string(number::integer(0, 255)) + "," + std::to_string(number::integer(0, 255)) + "," +
+           std::to_string(number::integer(0, 255)) + ")";
 }
 
-} // namespace
-
-std::string imageUrl(unsigned width, unsigned height) {
-  if (faker::datatype::boolean(0.5)) {
-    return urlLoremFlickr(width, height);
-  }
-
-  return urlPicsumPhotos(width, height);
 }
 
-std::string urlLoremFlickr(unsigned int width, unsigned int height,
-                           std::optional<ImageCategory> category) {
-  const std::string image_category =
-      category.has_value()
-          ? common::format("/{}", imageCategoryToLoremFlickrStringMapping.at(
-                                      category.value()))
-          : "";
-
-  return common::format("https://loremflickr.com/{}/{}{}", width, height,
-                        image_category);
-}
-
-std::string urlPicsumPhotos(unsigned width, unsigned height,
-                            const std::optional<bool> greyscale,
-                            const std::optional<int> blur) {
-  std::string url =
-      common::format("https://picsum.photos/{}/{}", width, height);
-  std::string params;
-
-  params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
-
-  if (blur.has_value()) {
-    if (blur.value() < 1 || blur.value() > 10) {
-      throw std::invalid_argument("Blur must be between 1 and 10");
+std::string imageUrl(unsigned width, unsigned height)
+{
+    if (faker::datatype::boolean(0.5))
+    {
+        return urlLoremFlickr(width, height);
     }
 
-    if (!params.empty()) {
-      params += "&";
+    return urlPicsumPhotos(width, height);
+}
+
+std::string urlLoremFlickr(unsigned int width, unsigned int height, std::optional<ImageCategory> category)
+{
+    const std::string image_category =
+        category.has_value() ? common::format("/{}", imageCategoryToLoremFlickrStringMapping.at(category.value())) : "";
+
+    return common::format("https://loremflickr.com/{}/{}{}", width, height, image_category);
+}
+
+std::string urlPicsumPhotos(unsigned width, unsigned height, const std::optional<bool> greyscale,
+                            const std::optional<int> blur)
+{
+    std::string url = common::format("https://picsum.photos/{}/{}", width, height);
+    std::string params;
+
+    params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
+
+    if (blur.has_value())
+    {
+        if (blur.value() < 1 || blur.value() > 10)
+        {
+            throw std::invalid_argument("Blur must be between 1 and 10");
+        }
+
+        if (!params.empty())
+        {
+            params += "&";
+        }
+
+        params += common::format("blur={}", blur.value());
     }
 
-    params += common::format("blur={}", blur.value());
-  }
+    if (!params.empty())
+    {
+        url = common::format("{}?{}", url, params);
+    }
 
-  if (!params.empty()) {
-    url = common::format("{}?{}", url, params);
-  }
-
-  return common::format("{}", url);
+    return common::format("{}", url);
 }
 
-std::string githubAvatarUrl() {
-  return common::format("https://avatars.githubusercontent.com/u/{}",
-                        number::integer<int>(100000000));
+std::string githubAvatarUrl()
+{
+    return common::format("https://avatars.githubusercontent.com/u/{}", number::integer<int>(100000000));
 }
 
-std::string dimensions() {
-  return common::format("{}x{}", number::integer<int>(1, 32720),
-                        number::integer<int>(1, 17280));
+std::string dimensions()
+{
+    return common::format("{}x{}", number::integer<int>(1, 32720), number::integer<int>(1, 17280));
 }
 
-std::string_view type() { return helper::randomElement(imageTypes); }
-
-std::string dataUri(unsigned width, unsigned height, const std::string &color,
-                    const std::string &type) {
-  std::ostringstream svgStream;
-  svgStream << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" "
-               "baseProfile=\"full\" "
-            << "width=\"" << width << "\" height=\"" << height << "\">"
-            << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
-            << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
-            << "\" font-size=\"20\" alignment-baseline=\"middle\" "
-               "text-anchor=\"middle\" fill=\"white\">"
-            << width << "x" << height << "</text></svg>";
-
-  const auto svgString = svgStream.str();
-
-  if (type == "svg-uri") {
-    return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);
-  } else if (type == "svg-base64") {
-    return "data:image/svg+xml;base64," + base64::encode(svgString);
-  } else {
-    throw std::invalid_argument(
-        "Invalid type specified. Use 'svg-uri' or 'svg-base64'.");
-  }
+std::string_view type()
+{
+    return helper::randomElement(imageTypes);
 }
-} // namespace faker::image
+
+std::string dataUri(unsigned width, unsigned height, const std::string& color, const std::string& type)
+{
+    std::ostringstream svgStream;
+    svgStream << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" baseProfile=\"full\" "
+              << "width=\"" << width << "\" height=\"" << height << "\">"
+              << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
+              << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
+              << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">" << width
+              << "x" << height << "</text></svg>";
+
+    const auto svgString = svgStream.str();
+
+    if (type == "svg-uri")
+    {
+        return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);
+    }
+    else if (type == "svg-base64")
+    {
+        return "data:image/svg+xml;base64," + base64::encode(svgString);
+    }
+    else
+    {
+        throw std::invalid_argument("Invalid type specified. Use 'svg-uri' or 'svg-base64'.");
+    }
+}
+}

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -27,9 +27,7 @@ std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringM
 };
 
 int randomInt(int min, int max) {
-    static std::mt19937 rng(std::time(nullptr));
-    std::uniform_int_distribution<int> dist(min, max);
-    return dist(rng);
+    return number::integer(min, max);
 }
 
 

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -26,15 +26,10 @@ std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringM
     {ImageCategory::Sports, "sports"},   {ImageCategory::Technics, "technics"}, {ImageCategory::Transport, "transport"},
 };
 
-int randomInt(int min, int max) {
-    return number::integer(min, max);
-}
-
-
 std::string randomColor() {
-    return "rgb(" + std::to_string(randomInt(0, 255)) + "," +
-           std::to_string(randomInt(0, 255)) + "," +
-           std::to_string(randomInt(0, 255)) + ")";
+    return "rgb(" + std::to_string(number::integer(0, 255)) + "," +
+           std::to_string(number::integer(0, 255)) + "," +
+           std::to_string(number::integer(0, 255)) + ")";
 }
 
 }

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -1,7 +1,6 @@
-#include "faker-cxx/image.h"
+#include <faker-cxx/datatype.h>
 
 #include <array>
-#include <faker-cxx/datatype.h>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -11,117 +10,120 @@
 #include "common/format_helper.h"
 #include "faker-cxx/base64.h"
 #include "faker-cxx/helper.h"
+#include "faker-cxx/image.h"
 #include "faker-cxx/number.h"
 
-namespace faker::image
-{
-namespace
-{
-const std::array<std::string_view, 15> imageTypes = {"ai",  "bmp", "eps", "gif", "heif", "indd", "jpeg", "jpg",
-                                                     "pdf", "png", "psd", "raw", "svg",  "tiff", "webp"};
+namespace faker::image {
+namespace {
+const std::array<std::string_view, 15> imageTypes = {
+    "ai",  "bmp", "eps", "gif", "heif", "indd", "jpeg", "jpg",
+    "pdf", "png", "psd", "raw", "svg",  "tiff", "webp"};
 
-std::unordered_map<ImageCategory, std::string> imageCategoryToLoremFlickrStringMapping = {
-    {ImageCategory::Animals, "animals"}, {ImageCategory::Business, "business"}, {ImageCategory::Cats, "cats"},
-    {ImageCategory::City, "city"},       {ImageCategory::Food, "food"},         {ImageCategory::Nightlife, "nightlife"},
-    {ImageCategory::Fashion, "fashion"}, {ImageCategory::People, "people"},     {ImageCategory::Nature, "nature"},
-    {ImageCategory::Sports, "sports"},   {ImageCategory::Technics, "technics"}, {ImageCategory::Transport, "transport"},
+std::unordered_map<ImageCategory, std::string>
+    imageCategoryToLoremFlickrStringMapping = {
+        {ImageCategory::Animals, "animals"},
+        {ImageCategory::Business, "business"},
+        {ImageCategory::Cats, "cats"},
+        {ImageCategory::City, "city"},
+        {ImageCategory::Food, "food"},
+        {ImageCategory::Nightlife, "nightlife"},
+        {ImageCategory::Fashion, "fashion"},
+        {ImageCategory::People, "people"},
+        {ImageCategory::Nature, "nature"},
+        {ImageCategory::Sports, "sports"},
+        {ImageCategory::Technics, "technics"},
+        {ImageCategory::Transport, "transport"},
 };
 
-std::string randomColor()
-{
-    return "rgb(" + std::to_string(number::integer(0, 255)) + "," + std::to_string(number::integer(0, 255)) + "," +
-           std::to_string(number::integer(0, 255)) + ")";
+std::string randomColor() {
+  return "rgb(" + std::to_string(number::integer(0, 255)) + "," +
+         std::to_string(number::integer(0, 255)) + "," +
+         std::to_string(number::integer(0, 255)) + ")";
 }
 
+}  // namespace
+
+std::string imageUrl(unsigned width, unsigned height) {
+  if (faker::datatype::boolean(0.5)) {
+    return urlLoremFlickr(width, height);
+  }
+
+  return urlPicsumPhotos(width, height);
 }
 
-std::string imageUrl(unsigned width, unsigned height)
-{
-    if (faker::datatype::boolean(0.5))
-    {
-        return urlLoremFlickr(width, height);
+std::string urlLoremFlickr(unsigned int width, unsigned int height,
+                           std::optional<ImageCategory> category) {
+  const std::string image_category =
+      category.has_value()
+          ? common::format("/{}", imageCategoryToLoremFlickrStringMapping.at(
+                                      category.value()))
+          : "";
+
+  return common::format("https://loremflickr.com/{}/{}{}", width, height,
+                        image_category);
+}
+
+std::string urlPicsumPhotos(unsigned width, unsigned height,
+                            const std::optional<bool> greyscale,
+                            const std::optional<int> blur) {
+  std::string url =
+      common::format("https://picsum.photos/{}/{}", width, height);
+  std::string params;
+
+  params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
+
+  if (blur.has_value()) {
+    if (blur.value() < 1 || blur.value() > 10) {
+      throw std::invalid_argument("Blur must be between 1 and 10");
     }
 
-    return urlPicsumPhotos(width, height);
-}
-
-std::string urlLoremFlickr(unsigned int width, unsigned int height, std::optional<ImageCategory> category)
-{
-    const std::string image_category =
-        category.has_value() ? common::format("/{}", imageCategoryToLoremFlickrStringMapping.at(category.value())) : "";
-
-    return common::format("https://loremflickr.com/{}/{}{}", width, height, image_category);
-}
-
-std::string urlPicsumPhotos(unsigned width, unsigned height, const std::optional<bool> greyscale,
-                            const std::optional<int> blur)
-{
-    std::string url = common::format("https://picsum.photos/{}/{}", width, height);
-    std::string params;
-
-    params += (greyscale.has_value() && greyscale.value()) ? "greyscale" : "";
-
-    if (blur.has_value())
-    {
-        if (blur.value() < 1 || blur.value() > 10)
-        {
-            throw std::invalid_argument("Blur must be between 1 and 10");
-        }
-
-        if (!params.empty())
-        {
-            params += "&";
-        }
-
-        params += common::format("blur={}", blur.value());
+    if (!params.empty()) {
+      params += "&";
     }
 
-    if (!params.empty())
-    {
-        url = common::format("{}?{}", url, params);
-    }
+    params += common::format("blur={}", blur.value());
+  }
 
-    return common::format("{}", url);
+  if (!params.empty()) {
+    url = common::format("{}?{}", url, params);
+  }
+
+  return common::format("{}", url);
 }
 
-std::string githubAvatarUrl()
-{
-    return common::format("https://avatars.githubusercontent.com/u/{}", number::integer<int>(100000000));
+std::string githubAvatarUrl() {
+  return common::format("https://avatars.githubusercontent.com/u/{}",
+                        number::integer<int>(100000000));
 }
 
-std::string dimensions()
-{
-    return common::format("{}x{}", number::integer<int>(1, 32720), number::integer<int>(1, 17280));
+std::string dimensions() {
+  return common::format("{}x{}", number::integer<int>(1, 32720),
+                        number::integer<int>(1, 17280));
 }
 
-std::string_view type()
-{
-    return helper::randomElement(imageTypes);
-}
+std::string_view type() { return helper::randomElement(imageTypes); }
 
-std::string dataUri(unsigned width, unsigned height, const std::string& color, const std::string& type)
-{
-    std::ostringstream svgStream;
-    svgStream << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" baseProfile=\"full\" "
-              << "width=\"" << width << "\" height=\"" << height << "\">"
-              << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
-              << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
-              << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">" << width
-              << "x" << height << "</text></svg>";
+std::string dataUri(unsigned width, unsigned height, const std::string &color,
+                    const std::string &type) {
+  std::ostringstream svgStream;
+  svgStream << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" "
+               "baseProfile=\"full\" "
+            << "width=\"" << width << "\" height=\"" << height << "\">"
+            << "<rect width=\"100%\" height=\"100%\" fill=\"" << color << "\"/>"
+            << "<text x=\"" << width / 2 << "\" y=\"" << height / 2
+            << "\" font-size=\"20\" alignment-baseline=\"middle\" "
+               "text-anchor=\"middle\" fill=\"white\">"
+            << width << "x" << height << "</text></svg>";
 
-    const auto svgString = svgStream.str();
+  const auto svgString = svgStream.str();
 
-    if (type == "svg-uri")
-    {
-        return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);
-    }
-    else if (type == "svg-base64")
-    {
-        return "data:image/svg+xml;base64," + base64::encode(svgString);
-    }
-    else
-    {
-        throw std::invalid_argument("Invalid type specified. Use 'svg-uri' or 'svg-base64'.");
-    }
+  if (type == "svg-uri") {
+    return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);
+  } else if (type == "svg-base64") {
+    return "data:image/svg+xml;base64," + base64::encode(svgString);
+  } else {
+    throw std::invalid_argument(
+        "Invalid type specified. Use 'svg-uri' or 'svg-base64'.");
+  }
 }
 }

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -112,7 +112,7 @@ std::string dataUri(unsigned width, unsigned height, const std::string &color, c
               << "\" font-size=\"20\" alignment-baseline=\"middle\" text-anchor=\"middle\" fill=\"white\">"
               << width << "x" << height << "</text></svg>";
 
-    std::string svgString = svgStream.str();
+    const auto svgString = svgStream.str();
 
     if (type == "svg-uri") {
         return common::format("data:image/svg+xml;charset=UTF-8,{}", svgString);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,7 +49,7 @@ set(FAKER_UT_SOURCES
     modules/weather_test.cpp
     modules/word_test.cpp
     modules/word_data_test.cpp
-    modules/base64.cpp
+    modules/base64_test.cpp
 )
 
 add_executable(${PROJECT_NAME} ${FAKER_UT_SOURCES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(FAKER_UT_SOURCES
     modules/weather_test.cpp
     modules/word_test.cpp
     modules/word_data_test.cpp
+    modules/base64.cpp
 )
 
 add_executable(${PROJECT_NAME} ${FAKER_UT_SOURCES})

--- a/tests/modules/airline_test.cpp
+++ b/tests/modules/airline_test.cpp
@@ -38,7 +38,8 @@ TEST_F(AirlineTest, shouldGenerateAirplane)
     const auto generatedAirplane = airplane();
 
     ASSERT_TRUE(std::ranges::any_of(airplanes,
-                                    [generatedAirplane](const Airplane& airplane) {
+                                    [generatedAirplane](const Airplane& airplane)
+                                    {
                                         return airplane.name == generatedAirplane.name &&
                                                airplane.iataTypeCode == generatedAirplane.iataTypeCode;
                                     }));

--- a/tests/modules/base64_test.cpp
+++ b/tests/modules/base64_test.cpp
@@ -1,0 +1,79 @@
+#include "faker-cxx/base64.h"
+
+#include <cstdint>
+
+static const char encodeLookup[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char padCharacter = '=';
+static const int B64index[256] = {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+                                  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+                                  0,  62, 63, 62, 62, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0,  0,  0,  0,  0,
+                                  0,  0,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                                  19, 20, 21, 22, 23, 24, 25, 0,  0,  0,  0,  63, 0,  26, 27, 28, 29, 30, 31, 32, 33,
+                                  34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
+
+namespace faker::base64
+{
+std::string encode(const std::string& input)
+{
+    std::string encodedString;
+    encodedString.reserve(((input.size() / 3) + (input.size() % 3 > 0)) * 4);
+    uint32_t temp;
+    auto cursor = input.begin();
+    for (size_t idx = 0; idx < input.size() / 3; ++idx)
+    {
+        temp = (*cursor++) << 16;
+        temp += (*cursor++) << 8;
+        temp += (*cursor++);
+        encodedString.append(1, encodeLookup[(temp & 0x00FC0000) >> 18]);
+        encodedString.append(1, encodeLookup[(temp & 0x0003F000) >> 12]);
+        encodedString.append(1, encodeLookup[(temp & 0x00000FC0) >> 6]);
+        encodedString.append(1, encodeLookup[(temp & 0x0000003F)]);
+    }
+    switch (input.size() % 3)
+    {
+    case 1:
+        temp = (*cursor++) << 16;
+        encodedString.append(1, encodeLookup[(temp & 0x00FC0000) >> 18]);
+        encodedString.append(1, encodeLookup[(temp & 0x0003F000) >> 12]);
+        encodedString.append(2, padCharacter);
+        break;
+    case 2:
+        temp = (*cursor++) << 16;
+        temp += (*cursor++) << 8;
+        encodedString.append(1, encodeLookup[(temp & 0x00FC0000) >> 18]);
+        encodedString.append(1, encodeLookup[(temp & 0x0003F000) >> 12]);
+        encodedString.append(1, encodeLookup[(temp & 0x00000FC0) >> 6]);
+        encodedString.append(1, padCharacter);
+        break;
+    }
+    return encodedString;
+}
+
+std::string decode(const void* data, const size_t len)
+{
+    unsigned char* p = (unsigned char*)data;
+    int pad = len > 0 && (len % 4 || p[len - 1] == '=');
+    const size_t L = ((len + 3) / 4 - pad) * 4;
+    std::string str(L / 4 * 3 + pad, '\0');
+
+    for (size_t i = 0, j = 0; i < L; i += 4)
+    {
+        int n = B64index[p[i]] << 18 | B64index[p[i + 1]] << 12 | B64index[p[i + 2]] << 6 | B64index[p[i + 3]];
+        str[j++] = n >> 16;
+        str[j++] = n >> 8 & 0xFF;
+        str[j++] = n & 0xFF;
+    }
+    if (pad)
+    {
+        int n = B64index[p[L]] << 18 | B64index[p[L + 1]] << 12;
+        str[str.size() - 1] = n >> 16;
+
+        if (len > L + 2 && p[L + 2] != '=')
+        {
+            n |= B64index[p[L + 2]] << 6;
+            str.push_back(n >> 8 & 0xFF);
+        }
+    }
+    return str;
+}
+}

--- a/tests/modules/crypto_test.cpp
+++ b/tests/modules/crypto_test.cpp
@@ -24,14 +24,15 @@ public:
 
         return std::regex_match(input, regexExp);
     }
+
     static bool isSHA1Hash(const std::string& input)
     {
-    if (input.length() != 40) {
-        return false;
-    }
-    return std::all_of(input.begin(), input.end(), [](char c) {
-        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
-    });
+        if (input.length() != 40)
+        {
+            return false;
+        }
+        return std::all_of(input.begin(), input.end(),
+                           [](char c) { return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'); });
     }
 };
 
@@ -114,7 +115,6 @@ TEST_F(CryptoTest, ChecksSHA1HashWithDataCodecov)
     const auto generatedRandomHash = sha1("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde");
     ASSERT_TRUE(isSHA1Hash(generatedRandomHash));
 }
-
 
 TEST_F(CryptoTest, ShouldGenerateMD5Hash)
 {

--- a/tests/modules/image_test.cpp
+++ b/tests/modules/image_test.cpp
@@ -7,6 +7,7 @@
 
 #include "common/string_helper.h"
 #include "faker-cxx/image.h"
+#include "faker-cxx/base64.h"
 
 using namespace ::testing;
 using namespace faker;
@@ -164,4 +165,50 @@ TEST_F(ImageTest, shouldGenerateType)
 
     ASSERT_TRUE(std::ranges::any_of(imageTypes,
                                     [generatedType](const std::string_view& type) { return type == generatedType; }));
+}
+
+TEST_F(ImageTest, shouldGenerateDataUriSvgUri)
+{
+    const auto width = 100;
+    const auto height = 100;
+    const auto color = "red";
+    const auto type = "svg-uri";
+
+    const auto generatedDataUri = dataUri(width, height, color, type);
+
+    ASSERT_TRUE(generatedDataUri.find("data:image/svg+xml;charset=UTF-8,") == 0);
+    ASSERT_TRUE(generatedDataUri.find("<svg") != std::string::npos);
+    ASSERT_TRUE(generatedDataUri.find("width=\"100\"") != std::string::npos);
+    ASSERT_TRUE(generatedDataUri.find("height=\"100\"") != std::string::npos);
+    ASSERT_TRUE(generatedDataUri.find("fill=\"red\"") != std::string::npos);
+}
+
+TEST_F(ImageTest, shouldGenerateDataUriSvgBase64)
+{
+    const auto width = 100;
+    const auto height = 100;
+    const auto color = "red";
+    const auto type = "svg-base64";
+
+    const auto generatedDataUri = dataUri(width, height, color, type);
+
+    ASSERT_TRUE(generatedDataUri.find("data:image/svg+xml;base64,") == 0);
+
+    const auto base64Data = generatedDataUri.substr(std::string("data:image/svg+xml;base64,").length());
+    const auto decodedData = base64::decode(base64Data.data(), base64Data.size());
+
+    ASSERT_TRUE(decodedData.find("<svg") != std::string::npos);
+    ASSERT_TRUE(decodedData.find("width=\"100\"") != std::string::npos);
+    ASSERT_TRUE(decodedData.find("height=\"100\"") != std::string::npos);
+    ASSERT_TRUE(decodedData.find("fill=\"red\"") != std::string::npos);
+}
+
+TEST_F(ImageTest, shouldThrowErrorForInvalidDataUriType)
+{
+    const auto width = 100;
+    const auto height = 100;
+    const auto color = "red";
+    const auto type = "invalid-type";
+
+    ASSERT_THROW(dataUri(width, height, color, type), std::invalid_argument);
 }

--- a/tests/modules/image_test.cpp
+++ b/tests/modules/image_test.cpp
@@ -6,8 +6,8 @@
 #include "gtest/gtest.h"
 
 #include "common/string_helper.h"
-#include "faker-cxx/image.h"
 #include "faker-cxx/base64.h"
+#include "faker-cxx/image.h"
 
 using namespace ::testing;
 using namespace faker;


### PR DESCRIPTION
### Description
This PR implements the `dataUri` function, which generates a random data URI containing either a URL-encoded SVG image or a Base64-encoded SVG image. It includes options for width, height, color, and type.

### Reason for Changes
This feature allows users to easily generate SVG images in a data URI format, which is useful for embedding images directly in HTML.

### Testing
I added unit tests for the `dataUri` function to ensure it generates valid SVG and Base64 URIs. All tests pass successfully.

### Related Issues
Fixes #1024: add dataUri function to Image module

### Additional Notes
Currently, the function only supports basic colors. Future work could include support for gradients.