### PR TITLE
feat: remove --enable_workspace flag from bazel workflow

### DIFF
--- a/.github/workflows/linux-bazel-build.yml
+++ b/.github/workflows/linux-bazel-build.yml
@@ -40,9 +40,9 @@ jobs:
             ${{ runner.os }}-
 
       - name: Build faker-cxx library
-        run: bazel build //:faker-cxx --enable_workspace
+        run: bazel build //:faker-cxx
 
       - name: Build and run faker-cxx tests
         run: |
-          bazel build //tests:faker-cxx-ut --enable_workspace
+          bazel build //tests:faker-cxx-ut 
           bazel-bin/tests/faker-cxx-ut

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,15 +1,16 @@
 # Define dependencies using Bzlmod.
+
 bazel_dep(
-    name = "rules_foreign_cc",
-    version = "0.10.1"
+    name = "rules_foreign_cc", 
+    version = "0.13.0"
 )
 
 bazel_dep(
     name = "googletest",
-    version = "1.14.0.bcr.1"
+    version = "1.15.0"
 )
 
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.16"
+    version = "0.1.0"
 )


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow file `.github/workflows/linux-bazel-build.yml` by removing the `--enable_workspace` flag from the Bazel build and test commands. 

The `--enable_workspace` flag is no longer needed as part of the migration from the legacy `WORKSPACE` system to the newer `Bzlmod` (MODULE.bazel) dependency management system. 

The following changes were made:

1. **Removed `--enable_workspace` Flag**:
   - The build command:
     ```bash
     bazel build //:faker-cxx --enable_workspace
     ```
     was updated to:
     ```bash
     bazel build //:faker-cxx
     ```

   - Similarly, the test command:
     ```bash
     bazel build //tests:faker-cxx-ut --enable_workspace
     bazel-bin/tests/faker-cxx-ut
     ```
     was updated to:
     ```bash
     bazel build //tests:faker-cxx-ut
     bazel-bin/tests/faker-cxx-ut
     ```

2. **Ensured Compatibility with Bzlmod**:
   - Dependencies previously managed in `WORKSPACE.bazel` have been migrated to `MODULE.bazel` using the `bazel_dep` format.
   - This change confirms that the build and test processes can run without relying on legacy configurations.

---

### **Testing**

- Verified that the Bazel build and test commands work correctly without the `--enable_workspace` flag.
- Ensured the workflow successfully builds the `faker-cxx` library and runs the `faker-cxx-ut` unit tests.

---

### **Acceptance Criteria**

The workflow should pass the following checks:
1. Successful execution of the Bazel build command:
   ```bash
   bazel build //:faker-cxx
   ```
2. Successful execution of the Bazel test command:
   ```bash
    bazel build //tests:faker-cxx-ut
    bazel-bin/tests/faker-cxx-ut
   ```

### Added
- Migrated to Bazel module system (Bzlmod).
- Added `MODULE.bazel` for managing dependencies.

### Changed
- Updated dependencies to new versions:
  - `rules_foreign_cc` updated to `0.13.0`
  - `googletest` updated to `1.14.0.bcr.1`
  - `rules_cc` updated to `0.1.0`
  
### Removed
- Removed `WORKSPACE.bazel` as part of the migration.
- Moved backup of `WORKSPACE.bazel` to the `workspace-backup` folder for reference.

### Fixed
- Cleaned up the `MODULE.bazel` file for minimal and accurate dependency management.
- Ran `bazel test` to ensure that the migration did not break the build.

 ### **Additional Notes**

3. Confirm compatibility with existing CI/CD pipelines to ensure a smooth transition to the updated Bazel dependency management system. 
4. Perform regression testing to verify that no unintended side effects arise from removing the `--enable_workspace` flag.

---

### **Impact**

This update removes technical debt associated with outdated Bazel flags, streamlines workflows, and improves project maintainability. Teams will no longer need to account for legacy configurations, ensuring more consistent and predictable behavior across builds.

By completing Phase 1 of the migration to Bzlmod, this project aligns with modern practices, setting the foundation for more scalable and efficient dependency management in future phases.

### Next Steps:
- Ensure all team members are using Bzlmod and its dependencies.
- Consider removing any unused dependencies or conflicting versions in the future."

