### PR TITLE
feat: use portable shebang for `format_code` bash script

### DIFF
--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 clang-format src/**/*.cpp src/**/*.h include/**/*.h -i -style=file


### PR DESCRIPTION
Bash is located in different places on different systems (e.g. `/bin/bash` for me). This PR changes the _format_code.sh_ script to use a portable shebang that works on all  *nix platforms by finding bash in the `PATH`.