### PR TITLE
feat: add random mgrs with specified precision

### DIFF
--- a/include/faker-cxx/location.h
+++ b/include/faker-cxx/location.h
@@ -167,6 +167,23 @@ FAKER_CXX_EXPORT std::string latitude(Precision precision = Precision::FourDp);
 FAKER_CXX_EXPORT std::string longitude(Precision precision = Precision::FourDp);
 
 /**
+ * @brief Generates a random Military Grid Reference System (MGRS) coordinate.
+ *
+ * @param precision An integer between 0 and 5, corresponding to the number of easting/northing digits. Defaults to 4.
+ *
+ * @returns std::string containing an MGRS coordinate with a valid format. (Note that the coordinate itself may not be a
+ * valid geospatial area, particularly in cases of higher precision and distance from equator. Also note that not all
+ * geospatial areas are covered by this function.)
+ *
+ * @throws std::invalid_argument if precision is not between 0 and 5.
+ *
+ * @code
+ * faker::location::mgrs() // "17SMD92712525"
+ * @endcode
+ */
+FAKER_CXX_EXPORT std::string mgrs(int precision = 4);
+
+/**
  * @brief Generates a random GPS coordinate within the specified radius from the given coordinate.
  *
  * @param precision The number of decimal points of precision for the latitude and longitude. Defaults to

--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -274,8 +274,8 @@ std::string mgrs(int precision)
 
     while (precision-- > 0)
     {
-        easting_block.push_back(number::integer<int8_t>('0', '9'));
-        northing_block.push_back(number::integer<int8_t>('0', '9'));
+        easting_block.push_back(static_cast<char>(number::integer<uint8_t>('0', '9')));
+        northing_block.push_back(static_cast<char>(number::integer<uint8_t>('0', '9')));
     }
     mgrs_str += easting_block;
     mgrs_str += northing_block;

--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -1,5 +1,6 @@
 #include "faker-cxx/location.h"
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <string_view>

--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -236,6 +236,51 @@ std::string longitude(Precision precision)
     return common::precisionFormat(precision, longitude);
 }
 
+std::string mgrs(int precision)
+{
+    if (precision < 0 || precision > 5)
+    {
+        throw std::invalid_argument("Precision must be between 0 and 5");
+    }
+    static const std::string_view eastings[] = {
+        "ABCDEFGH", // UTM zones 1-3
+        "JKLMNPQR", // UTM zones 4-6
+        "STUVWXYZ"  // UTM zones 7-9
+    };
+
+    // we avoid areas near the poles because the MGRS grid is not well defined there
+    static const std::string_view northings = "CDEFGHJKLMNPQRST";
+
+    std::string mgrs_str;
+    mgrs_str.reserve(static_cast<size_t>(precision * 2 + 4));
+    int zone = number::integer<uint8_t>(1, 60);
+
+    mgrs_str += std::to_string(zone);
+
+    char band = helper::randomElement(northings);
+    mgrs_str.push_back(band);
+
+    std::string_view easting_group = eastings[(zone - 1) % 3];
+
+    char grid1_idx = helper::randomElement(easting_group);
+    char grid2_idx = helper::randomElement(northings);
+
+    mgrs_str.push_back(grid1_idx);
+    mgrs_str.push_back(grid2_idx);
+
+    std::string easting_block = "";
+    std::string northing_block = "";
+
+    while (precision-- > 0)
+    {
+        easting_block.push_back(number::integer<int8_t>('0', '9'));
+        northing_block.push_back(number::integer<int8_t>('0', '9'));
+    }
+    mgrs_str += easting_block;
+    mgrs_str += northing_block;
+    return mgrs_str;
+}
+
 std::string_view direction()
 {
     return helper::randomElement(directions);
@@ -332,5 +377,4 @@ std::tuple<std::string, std::string> nearbyGPSCoordinate(Precision precision, co
     return {common::precisionFormat(precision, coordinateLatitude),
             common::precisionFormat(precision, coordinateLongitude)};
 }
-
 }

--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -253,8 +253,8 @@ std::string mgrs(int precision)
     static const std::string_view northings = "CDEFGHJKLMNPQRST";
 
     std::string mgrs_str;
-    mgrs_str.reserve(static_cast<size_t>(precision * 2 + 4));
-    int zone = number::integer<uint8_t>(1, 60);
+    mgrs_str.reserve(static_cast<size_t>(precision * 2 + 5));
+    int zone = number::integer(1, 60);
 
     mgrs_str += std::to_string(zone);
 
@@ -274,8 +274,8 @@ std::string mgrs(int precision)
 
     while (precision-- > 0)
     {
-        easting_block.push_back(static_cast<char>(number::integer<uint8_t>('0', '9')));
-        northing_block.push_back(static_cast<char>(number::integer<uint8_t>('0', '9')));
+        easting_block.push_back(static_cast<char>(number::integer(int('0'), int('9'))));
+        northing_block.push_back(static_cast<char>(number::integer(int('0'), int('9'))));
     }
     mgrs_str += easting_block;
     mgrs_str += northing_block;

--- a/tests/modules/location_test.cpp
+++ b/tests/modules/location_test.cpp
@@ -601,6 +601,55 @@ TEST_F(LocationTest, shouldGenerateLongitudeWithSpecifiedPrecision)
     ASSERT_LE(longitudeAsFloat, 180);
 }
 
+TEST_F(LocationTest, shouldGenerateMGRS)
+{
+    const auto generatedMGRS = mgrs();
+
+    bool zone_gt_10 = std::isdigit(generatedMGRS[1]);
+    size_t offset = 1;
+    int zone = generatedMGRS[0] - '0';
+    if (zone_gt_10)
+    {
+        zone = (zone * 10) + generatedMGRS[1] - '0';
+        offset++;
+    }
+    ASSERT_TRUE(zone >= 1 && zone <= 60);
+    char band = generatedMGRS[offset++]; // C-X (no I or O)
+    ASSERT_TRUE(band >= 'C' && band <= 'X');
+    std::string big_grid = generatedMGRS.substr(offset, 2);
+    ASSERT_TRUE(std::all_of(big_grid.begin(), big_grid.end(), ::isalpha));
+    offset += 2;
+    std::string eastnorth = generatedMGRS.substr(offset);
+    ASSERT_EQ(eastnorth.size(), 8);
+    ASSERT_TRUE(std::all_of(eastnorth.begin(), eastnorth.end(), ::isdigit));
+}
+
+TEST_F(LocationTest, shouldGenerateMGRSWithPrecision)
+{
+    for (int i = 0; i < 5; ++i)
+    {
+        const auto generatedMGRS = mgrs(i);
+
+        bool zone_gt_10 = std::isdigit(generatedMGRS[1]);
+        size_t offset = 1;
+        int zone = generatedMGRS[0] - '0';
+        if (zone_gt_10)
+        {
+            zone = (zone * 10) + generatedMGRS[1] - '0';
+            offset++;
+        }
+        ASSERT_TRUE(zone >= 1 && zone <= 60);
+        char band = generatedMGRS[offset++]; // C-X (no I or O)
+        ASSERT_TRUE(band >= 'C' && band <= 'X');
+        std::string big_grid = generatedMGRS.substr(offset, 2);
+        ASSERT_TRUE(std::all_of(big_grid.begin(), big_grid.end(), ::isalpha));
+        offset += 2;
+        std::string eastnorth = generatedMGRS.substr(offset);
+        ASSERT_EQ(eastnorth.size(), i * 2);
+        ASSERT_TRUE(std::all_of(eastnorth.begin(), eastnorth.end(), ::isdigit));
+    }
+}
+
 TEST_F(LocationTest, shouldGenerateNearbyGPSCoordinateWithoutOrigin)
 {
     const auto generatedNearbyGPSCoordinate = nearbyGPSCoordinate();
@@ -669,7 +718,7 @@ TEST_F(LocationTest, shouldGenerateNearbyGPSCoordinateWithOriginInMiles)
     ASSERT_EQ(generatedLongitudeParts[1].size(), 3);
 
     const auto distanceKm =
-            vincentyDistance(std::get<0>(origin), std::get<1>(origin), latitudeAsFloat, longitudeAsFloat);
+        vincentyDistance(std::get<0>(origin), std::get<1>(origin), latitudeAsFloat, longitudeAsFloat);
     const auto distanceMiles = distanceKm * 0.621371;
     constexpr double TOLERANCE = 1e-12;
 


### PR DESCRIPTION
Build and tests pass.

This PR adds an `mgrs(int precision = 4)` function, docs, and tests to the location submodule. The output is a syntactically (though possibly not semantically) valid [MGRS](https://en.wikipedia.org/wiki/Military_Grid_Reference_System) string that varies in precision based on its argument.

Not all outputs are valid grid references, and not all geospatial areas are covered. Specifically, areas near the poles are excluded from generation, since there is a higher probability that the grid reference will be invalid in those areas. Even so, this function will sometimes yield invalid MGRS coordinates.
