### PR TITLE
fix: `faker::number::octal` and `faker::number::binary(int)` return non-printable characters

### DIFF
--- a/src/modules/number.cpp
+++ b/src/modules/number.cpp
@@ -62,7 +62,7 @@ std::string octal(unsigned int length)
 
     for (unsigned int i = 0; i < length; ++i)
     {
-        octalNumber += static_cast<char>(number::integer(7));
+        octalNumber += number::integer('0', '7');
     }
 
     return "0o" + octalNumber;
@@ -79,7 +79,7 @@ std::string binary(int length)
 
     for (int i = 0; i < length; ++i)
     {
-        binaryNumber += static_cast<char>(number::integer(1));
+        binaryNumber += number::integer('0', '1');
     }
 
     return "0b" + binaryNumber;

--- a/tests/modules/number_test.cpp
+++ b/tests/modules/number_test.cpp
@@ -189,7 +189,7 @@ TEST_F(NumberTest, shouldGenerateOctalWithPrefix)
     ASSERT_EQ(generatedOctal.size(), octalLength + 2);
     ASSERT_EQ(prefix, "0o");
     ASSERT_TRUE(
-        std::ranges::any_of(generatedOctal, [](char octalNumberCharacter)
+        std::ranges::all_of(octalNumber, [](char octalNumberCharacter)
                             { return std::string("01234567").find(octalNumberCharacter) != std::string::npos; }));
 }
 
@@ -204,7 +204,7 @@ TEST_F(NumberTest, shouldGenerateBinary)
 
     ASSERT_EQ(generatedBinary.size(), binaryLength + 2);
     ASSERT_EQ(prefix, "0b");
-    ASSERT_TRUE(std::ranges::any_of(generatedBinary, [](char binaryNumberCharacter)
+    ASSERT_TRUE(std::ranges::all_of(binaryNumber, [](char binaryNumberCharacter)
                                     { return std::string("01").find(binaryNumberCharacter) != std::string::npos; }));
 }
 


### PR DESCRIPTION
Functions `faker::number::octal` and `faker::number::binary(int)` (the overload that takes a length), instead of returning a string with characters in the range `'0'-'7'` or `'0'-'1'`, respectively, were returning a string with non-printable characters whose numerical value is in the range `0-7` or `0-1`.
The related tests didn't fail because they didn't check it correctly.

resolves #1049