### PR TITLE
feat: Make `number::integer` support more integral types

### DIFF
--- a/include/faker-cxx/number.h
+++ b/include/faker-cxx/number.h
@@ -28,7 +28,8 @@ namespace faker::number
  * faker::number::integer(5, 10) // 7
  * @endcode
  */
-template <std::integral I> requires (sizeof(I) <= sizeof(long long))
+template <std::integral I>
+    requires(sizeof(I) <= sizeof(long long))
 I integer(I min, I max)
 {
     // std::uniform_int_distribution only accepts certain types, so we use signed or unsigned long long and don't allow
@@ -63,7 +64,8 @@ I integer(I min, I max)
  * faker::number::integer(10) // 5
  * @endcode
  */
-template <std::integral I> requires (sizeof(I) <= sizeof(long long))
+template <std::integral I>
+    requires(sizeof(I) <= sizeof(long long))
 I integer(I max)
 {
     return integer<I>(static_cast<I>(0), max);

--- a/include/faker-cxx/number.h
+++ b/include/faker-cxx/number.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <random>
 #include <stdexcept>
+#include <type_traits>
 
 #include "faker-cxx/export.h"
 #include "faker-cxx/generator.h"
@@ -17,7 +18,7 @@ namespace faker::number
  * @param min The minimum value of the range.
  * @param max The maximum value of the range.
  *
- * @tparam I the type of the generated number, must be an integral type (int, long, long long, etc.).
+ * @tparam I the type of the generated number, must be an integral type whose size is not larger than sizeof(long long).
  *
  * @throws std::invalid_argument if min is greater than max.
  *
@@ -27,9 +28,13 @@ namespace faker::number
  * faker::number::integer(5, 10) // 7
  * @endcode
  */
-template <std::integral I>
+template <std::integral I> requires (sizeof(I) <= sizeof(long long))
 I integer(I min, I max)
 {
+    // std::uniform_int_distribution only accepts certain types, so we use signed or unsigned long long and don't allow
+    // larger types
+    using LongLongType = std::conditional_t<std::is_unsigned_v<I>, unsigned long long, long long>;
+
     if (min > max)
     {
         throw std::invalid_argument("Minimum value must be smaller than maximum value.");
@@ -37,15 +42,15 @@ I integer(I min, I max)
 
     std::mt19937_64& pseudoRandomGenerator = getGenerator();
 
-    std::uniform_int_distribution<I> distribution(min, max);
+    std::uniform_int_distribution<LongLongType> distribution(min, max);
 
-    return distribution(pseudoRandomGenerator);
+    return static_cast<I>(distribution(pseudoRandomGenerator));
 }
 
 /**
  * @brief Generates a random integer between 0 and the given maximum value, bounds included.
  *
- * @tparam I the type of the generated number, must be an integral type (int, long, long long, etc.).
+ * @tparam I the type of the generated number, must be an integral type whose size is not larger than sizeof(long long).
  * @param max the maximum value of the range.
  *
  * @throws std::invalid_argument if min is greater than max.
@@ -58,7 +63,7 @@ I integer(I min, I max)
  * faker::number::integer(10) // 5
  * @endcode
  */
-template <std::integral I>
+template <std::integral I> requires (sizeof(I) <= sizeof(long long))
 I integer(I max)
 {
     return integer<I>(static_cast<I>(0), max);


### PR DESCRIPTION
Instead of using `std::uniform_int_distribution<I>`, which only supports certain integral types, use `std::uniform_int_distribution<[unsigned] long long>`, and allow any integral type not larger than `long long`.

<!-- Please run build and tests before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md#committing -->
