### PR TITLE
feat(location): add Albania (sq_AL) adress data and tests

### DIFF
--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -99,6 +99,8 @@ CountryAddressesInfo getAddresses(const Locale& locale)
         return japanAddresses;
     case Locale::lt_LT:
         return lithuaniaAddresses;
+    case Locale::sq_AL:
+        return albaniaAddresses;
     default:
         return usaAddresses;
     }

--- a/src/modules/location_data.h
+++ b/src/modules/location_data.h
@@ -14226,4 +14226,175 @@ const CountryAddressesInfo lithuaniaAddresses{
     .states = (lithuanianStates),
 };
 
+// Albania
+
+const auto albaniaCities = std::to_array<std::string_view>({
+    "Tirana",
+    "Durrës",
+    "Vlorë",
+    "Kamëz",
+    "Fier",
+    "Shkodër",
+    "Elbasan",
+    "Korçë",
+    "Sarandë",
+    "Berat",
+    "Lushnjë",
+    "Kavajë",
+    "Gjirokastër",
+    "Pogradec",
+    "Fushë-Krujë",
+    "Laç",
+    "Kukës",
+    "Sukth",
+    "Buçimas",
+    "Lezhë",
+    "Patos",
+    "Peshkopi",
+    "Librazhd-Qendër",
+    "Kuçovë",
+    "Krujë",
+    "Burrel",
+    "Perondi",
+    "Libonik",
+    "Rrëshen",
+    "Belsh",
+    "Divjakë",
+    "Gramsh",
+    "Mamurras",
+    "Bulqizë",
+    "Vau i Dejës",
+    "Shëngjin",
+    "Ballsh",
+    "Shijak",
+    "Bilisht",
+    "Rrogozhinë",
+    "Librazhd",
+    "Cërrik",
+    "Roskovec",
+    "Manzë",
+    "Peqin",
+    "Krumë",
+    "Përmet",
+    "Përrenjas-Fshat",
+    "Prrenjas",
+    "Delvinë",
+    "Orikum",
+    "Bajram Curri",
+    "Vorë",
+    "Këlcyrë",
+    "Ura Vajgurore",
+    "Himarë",
+    "Rubik",
+    "Tepelenë",
+    "Poliçan",
+    "Çorovodë",
+    "Ersekë",
+    "Maliq",
+    "Koplik",
+    "Pukë",
+    "Lazarat",
+    "Memaliaj",
+    "Velçan",
+    "Banaj",
+    "Fushë-Arrëz",
+    "Krrabë",
+    "Selenicë",
+    "Voskopojë",
+    "Bitinckë",
+    "Drenovë",
+    "Libohovë",
+    "Reps",
+    "Gjinkar",
+    "Krastë",
+    "Leskovik",
+    "Kurbnesh",
+    "Konispol",
+    "Finiq",
+    "Ulëz",
+    "Boboshticë",
+    "Sinaballaj",
+    "Liqenas",
+    "Aliaj",
+    "Burgajet",
+    "Plasë",
+    "Rapshë",
+    "Vukpalaj-Bajzë",
+    "Guri i Bardhë",
+    "Dobër",
+    "Kastrat",
+    "Bogiç-Palvar",
+    "Stërbeq",
+    "Shtanë",
+    "Vernicë",
+    "Goricë e Madhe",
+    "Dardhë",
+    "Vuno",
+    "Lajthizë",
+    "Gjinovec",
+    "Vërnik",
+    "Klenjë",
+    "Rripë"
+});
+
+const auto albaniaStates = std::to_array<std::string_view>({
+    "Berat County",
+    "Dibër County",
+    "Durrës County",
+    "Elbasan County",
+    "Fier County",
+    "Gjirokastër County",
+    "Korçë County",
+    "Kukës County",
+    "Lezhë County",
+    "Shkodër County",
+    "Tirana County"
+});
+
+const auto albaniaStreetSuffixes = std::to_array<std::string_view>({
+    "Rruga",
+    "Bulevardi",
+    "Sheshi",
+    "Rrugica",
+    "Autostrada",
+});
+
+const std::string_view albaniaZipCodeFormat{"####"};
+
+const auto albaniaAddressFormats = std::to_array<std::string_view>({
+    "{street} {buildingNumber}",
+    "{buildingNumber} {street}"
+});
+
+const auto albaniaBuildingNumberFormats = std::to_array<std::string_view>({
+    "#",
+    "##",
+    "###"
+});
+
+const auto albaniaStreetFormats = std::to_array<std::string_view>({
+    "{streetSuffix} {firstName}",
+    "{streetSuffix} {lastName}"
+});
+
+const auto albaniaCityFormats = std::to_array<std::string_view>({
+    "{cityName}"
+});
+
+const CountryAddressesInfo albaniaAddresses{
+    albaniaZipCodeFormat,
+    (albaniaAddressFormats),
+    {},                             // no secondary address formats
+    (albaniaStreetFormats),
+    {},                             // no street prefixes
+    {},                             // no street names list (we use suffixes)
+    (albaniaStreetSuffixes),
+    (albaniaBuildingNumberFormats),
+    (albaniaCityFormats),
+    {},                             // no city prefixes
+    (albaniaCities),
+    {},                             // no city suffixes
+    (albaniaStates),
+};
+
 }

--- a/tests/modules/location_test.cpp
+++ b/tests/modules/location_test.cpp
@@ -98,6 +98,8 @@ CountryAddressesInfo getAddresses(const Locale& locale)
         return japanAddresses;
     case Locale::lt_LT:
         return lithuaniaAddresses;
+    case Locale::sq_AL:
+        return albaniaAddresses;
     default:
         return usaAddresses;
     }
@@ -1457,4 +1459,25 @@ TEST_F(LocationTest, shouldGenerateLithuaniaStreetAddress)
     }
 }
 
+TEST_F(LocationTest, shouldGenerateAlbaniaStreetAddress)
+{
+    const auto generatedStreetAddress = streetAddress(Locale::sq_AL);
+
+    ASSERT_TRUE(std::ranges::any_of(albaniaStreetSuffixes,
+        [&generatedStreetAddress](const std::string_view& streetName)
+        {
+            return generatedStreetAddress.find(streetName) != std::string::npos;
+        }));
+}
+
+TEST_F(LocationTest, shouldGenerateAlbaniaStreet)
+{
+    const auto generatedStreet = street(Locale::sq_AL);
+
+    ASSERT_TRUE(std::ranges::any_of(albaniaStreetSuffixes,
+        [&generatedStreet](const std::string_view& streetName)
+        {
+            return generatedStreet.find(streetName) != std::string::npos;
+        }));
+}
 


### PR DESCRIPTION
**Overview**

* This pull request introduces comprehensive data for Albanian addresses, expanding the faker-cxx library’s functionality to generate realistic location-based information for the sq_AL locale.

**Changes Made**
* Added sq_AL Locale Data

* Implemented new data structures for the Albanian locale within location_data.h.

**Cities & States**

* Added an extensive list of Albanian cities (albaniaCities).

* Added counties as administrative regions (albaniaStates).

**Street Data**

* Introduced common Albanian street suffixes (albaniaStreetSuffixes) such as Rruga, Bulevardi, Sheshi, Rrugica, and Autostrada.

* Defined albaniaStreetFormats to align with Albanian naming conventions.

**Address Composition Rules**

* Defined albaniaAddressFormats to support both {street} {buildingNumber} and {buildingNumber} {street}.

* Defined albaniaBuildingNumberFormats using 1–3 digit formats.

**Zip Codes**

* Added Albanian postal code format (####).

**Unit Tests**

* Registered sq_AL locale in location_test.cpp.

Added:

- shouldGenerateAlbaniaStreet — validates generated street names include one of the Albanian street prefixes.

- shouldGenerateAlbaniaAddress — validates generated street addresses contain an Albanian street prefix.

**Why This Matters**

* This change enables developers to generate culturally realistic Albanian addresses, instead of generic placeholders. The addition of authentic street suffixes, city names, and address structures ensures data generated for Albania looks natural and representative of real-world usage.

All related tests are passing, including both general location tests and the new Albania-specific ones.