### PR TITLE
fix: eliminate build warnings by adding/removing static casts

### DIFF
--- a/src/common/algo_helper.h
+++ b/src/common/algo_helper.h
@@ -23,7 +23,7 @@ static T setElement(const std::set<T>& data)
         throw std::invalid_argument{"Data is empty."};
     }
 
-    T item;
+    T item{};
 
     std::mt19937_64& pseudoRandomGenerator = getGenerator();
 

--- a/src/modules/base64.cpp
+++ b/src/modules/base64.cpp
@@ -60,8 +60,8 @@ std::string decode(const void* data, const size_t len)
     {
         int n = B64index[p[i]] << 18 | B64index[p[i + 1]] << 12 | B64index[p[i + 2]] << 6 | B64index[p[i + 3]];
         str[j++] = static_cast<char>(n >> 16);
-        str[j++] = n >> 8 & 0xFF;
-        str[j++] = n & 0xFF;
+        str[j++] = static_cast<char>(n >> 8 & 0xFF);
+        str[j++] = static_cast<char>(n & 0xFF);
     }
     if (pad)
     {
@@ -71,7 +71,7 @@ std::string decode(const void* data, const size_t len)
         if (len > L + 2 && p[L + 2] != '=')
         {
             n |= B64index[p[L + 2]] << 6;
-            str.push_back(n >> 8 & 0xFF);
+            str.push_back(static_cast<char>(n >> 8 & 0xFF));
         }
     }
     return str;

--- a/src/modules/string.cpp
+++ b/src/modules/string.cpp
@@ -398,8 +398,8 @@ std::string uuidV1()
     auto time_hi_and_version = static_cast<uint16_t>((timestamp >> 48) & 0x0FFFULL);
     time_hi_and_version |= (1 << 12);
 
-    uint8_t clock_seq_low = clock_seq & 0xFF;
-    uint8_t clock_seq_hi_and_reserved = ((clock_seq >> 8) & 0x3F) | 0x80;
+    uint8_t clock_seq_low = static_cast<uint8_t>(clock_seq & 0xFF);
+    uint8_t clock_seq_hi_and_reserved = static_cast<uint8_t>(((clock_seq >> 8) & 0x3F) | 0x80);
 
     std::ostringstream ss;
     ss << std::hex << std::setfill('0');
@@ -449,8 +449,8 @@ std::string uuidV4()
 {
     RandomGenerator<std::mt19937_64> gen{getGenerator()};
 
-    static std::uniform_int_distribution<> dist(0, 15);
-    static std::uniform_int_distribution<> dist2(8, 11);
+    static std::uniform_int_distribution<size_t> dist(0, 15);
+    static std::uniform_int_distribution<size_t> dist2(8, 11);
     static std::string_view hexCharacters{"0123456789abcdef"};
 
     std::string result;
@@ -458,34 +458,34 @@ std::string uuidV4()
 
     for (int i = 0; i < 8; i++)
     {
-        result.append(1, hexCharacters[static_cast<size_t>(gen(dist))]);
+        result.append(1, hexCharacters[gen(dist)]);
     }
     result.append(1, '-');
 
     for (int i = 0; i < 4; i++)
     {
-        result.append(1, hexCharacters[static_cast<size_t>(gen(dist))]);
+        result.append(1, hexCharacters[gen(dist)]);
     }
     result.append(1, '-');
 
     result.append(1, '4');
     for (int i = 0; i < 3; i++)
     {
-        result.append(1, hexCharacters[static_cast<size_t>(gen(dist))]);
+        result.append(1, hexCharacters[gen(dist)]);
     }
     result.append(1, '-');
 
-    result.append(1, hexCharacters[static_cast<size_t>(gen(dist2))]);
+    result.append(1, hexCharacters[gen(dist2)]);
 
     for (int i = 0; i < 3; i++)
     {
-        result.append(1, hexCharacters[static_cast<size_t>(gen(dist))]);
+        result.append(1, hexCharacters[gen(dist)]);
     }
     result.append(1, '-');
 
     for (int i = 0; i < 12; i++)
     {
-        result.append(1, hexCharacters[static_cast<size_t>(gen(dist))]);
+        result.append(1, hexCharacters[gen(dist)]);
     }
 
     return result;
@@ -566,8 +566,8 @@ std::string uuidV6()
     auto time_low_and_version = static_cast<uint16_t>(timestamp & 0x0FFFULL);
     time_low_and_version |= (6 << 12); // Set version to 6
 
-    uint8_t clock_seq_low = clock_seq & 0xFF;
-    uint8_t clock_seq_hi_and_reserved = ((clock_seq >> 8) & 0x3F) | 0x80;
+    uint8_t clock_seq_low = static_cast<uint8_t>(clock_seq & 0xFF);
+    uint8_t clock_seq_hi_and_reserved = static_cast<uint8_t>(((clock_seq >> 8) & 0x3F) | 0x80);
 
     std::ostringstream ss;
     ss << std::hex << std::setfill('0');

--- a/tests/modules/base64_test.cpp
+++ b/tests/modules/base64_test.cpp
@@ -60,8 +60,8 @@ std::string decode(const void* data, const size_t len)
     {
         int n = B64index[p[i]] << 18 | B64index[p[i + 1]] << 12 | B64index[p[i + 2]] << 6 | B64index[p[i + 3]];
         str[j++] = static_cast<char>(n >> 16);
-        str[j++] = n >> 8 & 0xFF;
-        str[j++] = n & 0xFF;
+        str[j++] = static_cast<char>(n >> 8 & 0xFF);
+        str[j++] = static_cast<char>(n & 0xFF);
     }
     if (pad)
     {
@@ -71,7 +71,7 @@ std::string decode(const void* data, const size_t len)
         if (len > L + 2 && p[L + 2] != '=')
         {
             n |= B64index[p[L + 2]] << 6;
-            str.push_back(n >> 8 & 0xFF);
+            str.push_back(static_cast<char>(n >> 8 & 0xFF));
         }
     }
     return str;


### PR DESCRIPTION
```
$ ctest
Test project /workspaces/faker-cxx/build/Release
    Start 1: faker-cxx-UT
1/1 Test #1: faker-cxx-UT .....................   Passed    0.87 sec
```

This PR eliminates (at least g++) build warnings by explicitly `static_cast`ing in several places, and fixing the RNG distribution to explicitly return `size_t` in `string.cpp`.

It also fixes a spurious "use of uninitialized variable" warning in `algo_helper.h`.

This allows inclusion in environments that insist on `-Werror`.

Tested using g++ 13.3.0 on Ubuntu 24.04.

As an aside: we could probably specify `auto` for variables that are now assigned to `static_cast` outputs, but I was unsure of your preference here so I minimized the changes.