### PR TITLE
feat: Add location addresses for Austria (de_AT)

### DIFF
--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -43,6 +43,8 @@ CountryAddressesInfo getAddresses(const Locale& locale)
         return italyAddresses;
     case Locale::de_DE:
         return germanyAddresses;
+    case Locale::de_AT:
+        return austriaAddresses;
     case Locale::cs_CZ:
         return czechAddresses;
     case Locale::en_AU:

--- a/src/modules/location_data.h
+++ b/src/modules/location_data.h
@@ -15932,6 +15932,150 @@ const auto albaniaCityFormats = std::to_array<std::string_view>({
     "{cityName}"
 });
 
+// Austria
+
+const auto austriaCities = std::to_array<std::string_view>({
+    "Vienna",
+    "Graz",
+    "Linz",
+    "Salzburg",
+    "Innsbruck",
+    "Klagenfurt",
+    "Villach",
+    "Wels",
+    "Sankt Pölten",
+    "Dornbirn",
+    "Wiener Neustadt",
+    "Steyr",
+    "Feldkirch",
+    "Bregenz",
+    "Leoben",
+    "Leonding",
+    "Traun",
+    "Lustenau",
+    "Hohenems",
+    "Kapfenberg",
+    "Lienz",
+    "Hallein",
+    "Bad Hofgastein",
+    "Telfs",
+    "Enns",
+    "Kufstein",
+    "Gmunden",
+    "Eferding",
+});
+
+const auto austriaStates = std::to_array<std::string_view>({
+    "Vienna",
+    "Lower Austria",
+    "Upper Austria",
+    "Salzburg",
+    "Tyrol",
+    "Vorarlberg",
+    "Carinthia",
+    "Styria",
+    "Burgenland",
+});
+
+const auto austriaStreetNames = std::to_array<std::string_view>({
+    "Hauptstraße",
+    "Bahnhofstraße",
+    "Marktstraße",
+    "Schulstraße",
+    "Dorfstraße",
+    "Bergstraße",
+    "Kaiserstraße",
+    "Ringstraße",
+    "Karlstraße",
+    "Beethovenstraße",
+    "Mozartstraße",
+    "Straußstraße",
+    "Brahmsstraße",
+    "Sebastianplatz",
+    "Stephansplatz",
+    "Heldenplatz",
+    "Burgring",
+    "Schönbrunner Straße",
+    "Mariahilfer Straße",
+    "Kärntner Straße",
+    "Graben",
+    "Kohlmarkt",
+    "Tuchlauben",
+    "Florianigasse",
+    "Grosse Pfarrgasse",
+    "Rotenturmstraße",
+    "Wollzeile",
+    "Landskrongasse",
+    "Renngasse",
+    "Walfischgasse",
+    "Biberstraße",
+    "Singerstraße",
+    "Domgasse",
+    "Blutgasse",
+    "Jasomirgottstraße",
+    "Bankgasse",
+    "Stallburggasse",
+    "Minoritenplatz",
+    "Minoritenstraße",
+    "Neutorgasse",
+    "Ballgasse",
+    "Schreyvogelgasse",
+    "Judenplatz",
+    "Hallauerstraße",
+    "Universitätsstraße",
+    "Salzgries",
+    "Fleischmarkt",
+    "Börsegasse",
+    "Kurrentgasse",
+    "Stubenring",
+    "Beatrixgasse",
+});
+
+const std::string_view austriaZipCodeFormat{"####"};
+
+const auto austriaAddressFormats = std::to_array<std::string_view>({
+    "{buildingNumber} {street}",
+    "{street} {buildingNumber}",
+});
+
+const auto austriaBuildingNumberFormats = std::to_array<std::string_view>({
+    "#",
+    "##",
+    "###",
+});
+
+const auto austriaSecondaryAddressFormats = std::to_array<std::string_view>({
+    "Apt. #",
+    "Apt. ##",
+    "Wohnung #",
+    "Wohnung ##",
+    "Stock #",
+});
+
+const auto austriaStreetFormats = std::to_array<std::string_view>({
+    "{streetName} {buildingNumber}",
+});
+
+const auto austriaCityFormats = std::to_array<std::string_view>({
+    "{cityName}",
+});
+
+const CountryAddressesInfo austriaAddresses{
+    austriaZipCodeFormat,
+    (austriaAddressFormats),
+    (austriaSecondaryAddressFormats),
+    (austriaStreetFormats),
+    {},                             // no street prefixes
+    (austriaStreetNames),
+    {},                             // no street suffixes
+    (austriaBuildingNumberFormats),
+    (austriaCityFormats),
+    {},                             // no city prefixes
+    (austriaCities),
+    {},                             // no city suffixes
+    (austriaStates),
+};
+
 const CountryAddressesInfo albaniaAddresses{
     albaniaZipCodeFormat,
     (albaniaAddressFormats),

--- a/tests/modules/location_test.cpp
+++ b/tests/modules/location_test.cpp
@@ -42,6 +42,8 @@ CountryAddressesInfo getAddresses(const Locale& locale)
         return italyAddresses;
     case Locale::de_DE:
         return germanyAddresses;
+    case Locale::de_AT:
+        return austriaAddresses;
     case Locale::cs_CZ:
         return czechAddresses;
     case Locale::en_AU:


### PR DESCRIPTION
Adds Austrian location support including:
- 28 major Austrian cities
- 50+ authentic street names
- All 9 federal states (Bundesländer)
- Austrian postal code format (4 digits)
- Building number and secondary address formats

Closes #138

<!-- Please run build and tests before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md#committing -->
