### PR TITLE
feat: Adding location data for Sweden (sv_SE)

### DIFF
--- a/include/faker-cxx/types/locale.h
+++ b/include/faker-cxx/types/locale.h
@@ -260,7 +260,7 @@ const std::vector<Locale> locales{
 
 inline const std::set<Locale> postCodeSet{Locale::cy_GB,  Locale::gd_GB, Locale::en_GB, Locale::en_CA, Locale::fr_CA,
                                           Locale::moh_CA, Locale::fy_NL, Locale::nl_NL, Locale::es_AR, Locale::ms_BN,
-                                          Locale::mt_MT,  Locale::en_MT, Locale::lt_LT};
+                                          Locale::mt_MT,  Locale::en_MT, Locale::lt_LT, Locale::sv_SE};
 
 inline std::string toString(Locale locale)
 {

--- a/src/modules/location.cpp
+++ b/src/modules/location.cpp
@@ -99,6 +99,8 @@ CountryAddressesInfo getAddresses(const Locale& locale)
         return romaniaAddresses;
     case Locale::nb_NO:
         return norwayAddresses;
+    case Locale::sv_SE:
+        return swedenAddresses;
     case Locale::is_IS:
         return icelandAddresses;
     case Locale::tr_TR:

--- a/src/modules/location_data.h
+++ b/src/modules/location_data.h
@@ -15139,6 +15139,169 @@ const CountryAddressesInfo norwayAddresses{
     (norwayStates),
 };
 
+// Sweden
+
+const auto swedenCities = std::to_array<std::string_view>({
+    "Stockholm",
+    "Göteborg",
+    "Malmö",
+    "Uppsala",
+    "Västerås",
+    "Örebro",
+    "Linköping",
+    "Helsingborg",
+    "Jönköping",
+    "Norrköping",
+    "Lund",
+    "Umeå",
+    "Gävle",
+    "Södertälje",
+    "Borås",
+    "Växjö",
+    "Halmstad",
+    "Sundsvall",
+    "Eskilstuna",
+    "Karlstad",
+    "Östersund",
+    "Trollhättan",
+    "Luleå",
+    "Kalmar",
+    "Nyköping",
+    "Karlskrona",
+    "Trelleborg",
+    "Strängnäs",
+    "Kiruna",
+    "Boden",
+    "Visby",
+    "Värnamo",
+    "Åre",
+});
+
+const auto swedenStates = std::to_array<std::string_view>({
+    "Blekinge län",
+    "Dalarnas län",
+    "Gävleborgs län",
+    "Gotlands län",
+    "Hallands län",
+    "Jämtlands län",
+    "Jönköpings län",
+    "Kalmar län",
+    "Kronobergs län",
+    "Norrbottens län",
+    "Örebro län",
+    "Östergötlands län",
+    "Skåne län",
+    "Södermanlands län",
+    "Stockholms län",
+    "Uppsala län",
+    "Värmlands län",
+    "Västerbottens län",
+    "Västernorrlands län",
+    "Västmanlands län",
+    "Västra Götalands län",
+});
+
+const auto swedenStreetNames = std::to_array<std::string_view>({
+    "Odengatan",
+    "Sveavägen",
+    "Ringögatan",
+    "Storhöjdsgatan",
+    "Delsjövägen",
+    "Drottninggatan",
+    "Järnvägsgatan",
+    "Källgatan",
+    "Lilla Varvsgatan",
+    "Kvalitetsvägen",
+    "Amiralsgatan",
+    "Lännaplan",
+    "Gullmarsplan",
+    "Kungsträgårdsgatan",
+    "Strandvägen",
+    "Olaf Palmes gata",
+    "Fleminggatan",
+    "Hamngatan",
+    "Regeringsgatan",
+    "Karlavägen",
+    "Atterbomsgatan",
+    "Odins väg",
+    "Barlows väg",
+    "Skärgårdsvägen",
+    "Värdshusvägen",
+    "Österleden",
+    "Platågatan",
+    "Nygatan",
+    "Storgatan",
+    "Brogatan",
+    "Skråmträskvägen",
+    "Stationsgatan",
+    "Ekvägen",
+    "Kungsgatan",
+    "Norra Industrigatan",
+    "Älgvägen",
+    "Byggmästaregatan",
+    "Kämpevägen",
+    "Sjukhusgatan",
+    "Vildvinsbacken",
+    "Blomgatan",
+    "Konstdammsvägen",
+    "Turistvägen",
+    "Köpmangatan",
+    "Ringvägen",
+    "Hotellgatan",
+    "Björnstigen",
+    "Husingeplan",
+    "Biskop Henriks väg",
+    "Fabriksgatan",
+});
+
+const std::string_view swedenPostCodeFormat{"### ##"};
+
+const auto swedenAddressFormats = std::to_array<std::string_view>({
+    "{street} {buildingNumber}",
+    "{street} {buildingNumber} {secondaryAddress}",
+});
+
+const auto swedenBuildingNumberFormats = std::to_array<std::string_view>({
+    "#",
+    "##",
+    "###",
+    "#A",
+    "#B",
+    "##A",
+    "##B",
+});
+
+const auto swedenSecondaryAddressFormats = std::to_array<std::string_view>({
+    "Lägenhet #",
+    "Lägenhet #A",
+    "Lgh #",
+    "Lgh #A",
+});
+
+const auto swedenStreetFormats = std::to_array<std::string_view>({
+    "{streetName} {buildingNumber}",
+});
+
+const auto swedenCityFormats = std::to_array<std::string_view>({
+    "{cityName}",
+});
+
+const CountryAddressesInfo swedenAddresses{
+    swedenPostCodeFormat,
+    (swedenAddressFormats),
+    (swedenSecondaryAddressFormats),
+    (swedenStreetFormats),
+    {},                             // no street prefixes
+    (swedenStreetNames),
+    {},                             // no street suffixes
+    (swedenBuildingNumberFormats),
+    (swedenCityFormats),
+    {},                             // no city prefixes
+    (swedenCities),
+    {},                             // no city suffixes
+    (swedenStates),
+};
+
 // Turkey
 
 const auto turkeyCities = std::to_array<std::string_view>({

--- a/tests/modules/location_test.cpp
+++ b/tests/modules/location_test.cpp
@@ -100,6 +100,8 @@ CountryAddressesInfo getAddresses(const Locale& locale)
         return icelandAddresses;
     case Locale::nb_NO:
         return norwayAddresses;
+    case Locale::sv_SE:
+        return swedenAddresses;
     case Locale::tr_TR:
         return turkeyAddresses;
     case Locale::ja_JP:


### PR DESCRIPTION
Adds Swedish location support including:
- 33 Swedish Cities
- 50 street names
- All 21 län
- Swedish postal code format (### ##)

Closes #147

<!-- Please run build and tests before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/cieslarmichal/faker-cxx/blob/main/CONTRIBUTING.md#committing -->
