### PR TITLE
fix: handle empty separator in split function

### DIFF
--- a/src/common/string_helper.cpp
+++ b/src/common/string_helper.cpp
@@ -9,6 +9,11 @@ namespace faker::common
 {
 std::vector<std::string> split(const std::string& data, const std::string& separator)
 {
+    if (separator.empty())
+    {
+        return {data};
+    }
+
     size_t positionStart = 0;
     size_t positionEnd;
     size_t separatorLength = separator.length();

--- a/tests/common/string_helper_test.cpp
+++ b/tests/common/string_helper_test.cpp
@@ -34,6 +34,14 @@ TEST_F(StringHelperTest, splitStringByNewLine)
     ASSERT_EQ(result[3], "source");
 }
 
+TEST_F(StringHelperTest, splitStringByNothing)
+{
+    const auto result = common::split("fakercxxopensource", "");
+
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_EQ(result[0], "fakercxxopensource");
+}
+
 TEST_F(StringHelperTest, joinStringViewsWithoutString)
 {
     const std::vector<std::string_view> input{};


### PR DESCRIPTION
Add early return in `split()` when separator is empty.

Previously, calling `split(data, "")` would result in undefined behaviour as `std::string::find` with an empty string always returns the current position, causing an infinite loop. Now returns `{data}` immediately when separator is empty.